### PR TITLE
build: step-by-step build fixes and user-friendly improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,8 @@ cd scripts && docker build -t gem5-run:local -f Dockerfile.run . && cd ..
 # Option B: manual (build Docker image first — json-c needed by ext/libvfio-user)
 cd scripts && docker build -t gem5-run:local -f Dockerfile.run . && cd ..
 cd gem5 && docker run --rm -v "$(pwd):/gem5" -w /gem5 \
-    -e PYTHONPATH=/usr/lib/python3.12/lib-dynload \
     gem5-run:local \
-    bash -c "scons build/VEGA_X86/gem5.opt -j4 GOLD_LINKER=True --linker=gold"
+    scons build/VEGA_X86/gem5.opt -j4
 cd ../qemu && mkdir -p build && cd build && ../configure --target-list=x86_64-softmmu && make -j$(nproc)
 cd ../..
 docker run --rm -v "$(pwd)/gem5:/gem5" -w /gem5 gem5-run:local \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,14 +7,15 @@
 ./scripts/run_mi300x_fs.sh build-all
 cd scripts && docker build -t gem5-run:local -f Dockerfile.run . && cd ..
 
-# Option B: manual
+# Option B: manual (build Docker image first — json-c needed by ext/libvfio-user)
+cd scripts && docker build -t gem5-run:local -f Dockerfile.run . && cd ..
 cd gem5 && docker run --rm -v "$(pwd):/gem5" -w /gem5 \
     -e PYTHONPATH=/usr/lib/python3.12/lib-dynload \
-    ghcr.io/gem5/gpu-fs:latest \
+    gem5-run:local \
     bash -c "scons build/VEGA_X86/gem5.opt -j4 GOLD_LINKER=True --linker=gold"
 cd ../qemu && mkdir -p build && cd build && ../configure --target-list=x86_64-softmmu && make -j$(nproc)
-cd ../../scripts && docker build -t gem5-run:local -f Dockerfile.run . && cd ..
-docker run --rm -v "$(pwd)/gem5:/gem5" -w /gem5 ghcr.io/gem5/gpu-fs:latest \
+cd ../..
+docker run --rm -v "$(pwd)/gem5:/gem5" -w /gem5 gem5-run:local \
     bash -c "cd util/m5 && scons build/x86/out/m5"
 cp gem5/util/m5/build/x86/out/m5 gem5-resources/src/x86-ubuntu-gpu-ml/files/
 ./scripts/run_mi300x_fs.sh build-disk

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ git clone --recurse-submodules git@github.com:zevorn/cosim.git
 cd cosim
 
 # Build gem5 + QEMU + disk image (~2h total, needs KVM + Docker + ~60GB disk)
-GEM5_BUILD_IMAGE=ghcr.io/gem5/gpu-fs:latest ./scripts/run_mi300x_fs.sh build-all
+# This auto-builds the Docker image with json-c (needed by ext/libvfio-user)
+./scripts/run_mi300x_fs.sh build-all
 
 # Build runtime Docker image (for running gem5 inside Docker)
 cd scripts && docker build -t gem5-run:local -f Dockerfile.run . && cd ..
@@ -68,16 +69,16 @@ cd scripts && docker build -t gem5-run:local -f Dockerfile.run . && cd ..
 git clone --recurse-submodules git@github.com:zevorn/cosim.git
 cd cosim
 
-# 2. Build gem5 (in Docker, ~30min; use -j1 if OOM-killed during linking)
+# 2. Build Docker image (adds json-c needed by ext/libvfio-user)
+cd scripts && docker build -t gem5-run:local -f Dockerfile.run . && cd ..
+
+# 3. Build gem5 (in Docker, ~30min; use -j1 if OOM-killed during linking)
 cd gem5
 docker run --rm -v "$(pwd):/gem5" -w /gem5 \
     -e PYTHONPATH=/usr/lib/python3.12/lib-dynload \
-    ghcr.io/gem5/gpu-fs:latest \
+    gem5-run:local \
     bash -c "scons build/VEGA_X86/gem5.opt -j4 GOLD_LINKER=True --linker=gold"
 cd ..
-
-# 3. Build runtime Docker image (for running gem5 inside Docker)
-cd scripts && docker build -t gem5-run:local -f Dockerfile.run . && cd ..
 
 # 4. Build QEMU (stock build; vfio-user-pci is built-in since QEMU 10.0)
 cd qemu && mkdir -p build && cd build
@@ -87,7 +88,7 @@ cd ../..
 
 # 5. Pre-build m5 utility (recommended — avoids git clone inside guest VM)
 docker run --rm -v "$(pwd)/gem5:/gem5" -w /gem5 \
-    ghcr.io/gem5/gpu-fs:latest \
+    gem5-run:local \
     bash -c "cd util/m5 && scons build/x86/out/m5"
 cp gem5/util/m5/build/x86/out/m5 gem5-resources/src/x86-ubuntu-gpu-ml/files/
 

--- a/README.md
+++ b/README.md
@@ -75,9 +75,8 @@ cd scripts && docker build -t gem5-run:local -f Dockerfile.run . && cd ..
 # 3. Build gem5 (in Docker, ~30min; use -j1 if OOM-killed during linking)
 cd gem5
 docker run --rm -v "$(pwd):/gem5" -w /gem5 \
-    -e PYTHONPATH=/usr/lib/python3.12/lib-dynload \
     gem5-run:local \
-    bash -c "scons build/VEGA_X86/gem5.opt -j4 GOLD_LINKER=True --linker=gold"
+    scons build/VEGA_X86/gem5.opt -j4
 cd ..
 
 # 4. Build QEMU (stock build; vfio-user-pci is built-in since QEMU 10.0)

--- a/README.zh.md
+++ b/README.zh.md
@@ -51,7 +51,8 @@ git clone --recurse-submodules git@github.com:zevorn/cosim.git
 cd cosim
 
 # 构建 gem5 + QEMU + 磁盘镜像（总计约 2 小时，需要 KVM + Docker + 约 60GB 磁盘空间）
-GEM5_BUILD_IMAGE=ghcr.io/gem5/gpu-fs:latest ./scripts/run_mi300x_fs.sh build-all
+# 会自动构建包含 json-c 的 Docker 镜像（ext/libvfio-user 编译依赖）
+./scripts/run_mi300x_fs.sh build-all
 
 # 构建运行时 Docker 镜像（用于在 Docker 内运行 gem5）
 cd scripts && docker build -t gem5-run:local -f Dockerfile.run . && cd ..
@@ -67,16 +68,16 @@ cd scripts && docker build -t gem5-run:local -f Dockerfile.run . && cd ..
 git clone --recurse-submodules git@github.com:zevorn/cosim.git
 cd cosim
 
-# 2. 编译 gem5（Docker 内，约 30 分钟；链接阶段 OOM 可改用 -j1）
+# 2. 构建 Docker 镜像（添加 ext/libvfio-user 编译所需的 json-c）
+cd scripts && docker build -t gem5-run:local -f Dockerfile.run . && cd ..
+
+# 3. 编译 gem5（Docker 内，约 30 分钟；链接阶段 OOM 可改用 -j1）
 cd gem5
 docker run --rm -v "$(pwd):/gem5" -w /gem5 \
     -e PYTHONPATH=/usr/lib/python3.12/lib-dynload \
-    ghcr.io/gem5/gpu-fs:latest \
+    gem5-run:local \
     bash -c "scons build/VEGA_X86/gem5.opt -j4 GOLD_LINKER=True --linker=gold"
 cd ..
-
-# 3. 构建运行时 Docker 镜像（用于在 Docker 内运行 gem5）
-cd scripts && docker build -t gem5-run:local -f Dockerfile.run . && cd ..
 
 # 4. 编译 QEMU（标准构建；vfio-user-pci 自 QEMU 10.0 起内置）
 cd qemu && mkdir -p build && cd build
@@ -86,7 +87,7 @@ cd ../..
 
 # 5. 预编译 m5 工具（推荐 - 避免构建磁盘镜像时在 Guest 内 git clone）
 docker run --rm -v "$(pwd)/gem5:/gem5" -w /gem5 \
-    ghcr.io/gem5/gpu-fs:latest \
+    gem5-run:local \
     bash -c "cd util/m5 && scons build/x86/out/m5"
 cp gem5/util/m5/build/x86/out/m5 gem5-resources/src/x86-ubuntu-gpu-ml/files/
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -74,9 +74,8 @@ cd scripts && docker build -t gem5-run:local -f Dockerfile.run . && cd ..
 # 3. 编译 gem5（Docker 内，约 30 分钟；链接阶段 OOM 可改用 -j1）
 cd gem5
 docker run --rm -v "$(pwd):/gem5" -w /gem5 \
-    -e PYTHONPATH=/usr/lib/python3.12/lib-dynload \
     gem5-run:local \
-    bash -c "scons build/VEGA_X86/gem5.opt -j4 GOLD_LINKER=True --linker=gold"
+    scons build/VEGA_X86/gem5.opt -j4
 cd ..
 
 # 4. 编译 QEMU（标准构建；vfio-user-pci 自 QEMU 10.0 起内置）

--- a/docs/en/build-disk-china-mirror.md
+++ b/docs/en/build-disk-china-mirror.md
@@ -1,0 +1,26 @@
+[中文](../zh/build-disk-china-mirror.md)
+
+# Disk Image Build Acceleration Patch (China Network)
+
+## Problem
+
+On a China-based direct connection, `./scripts/run_mi300x_fs.sh build-disk`
+often hangs because `apt` inside the VM fetches packages from
+`us.archive.ubuntu.com` (Packer reports `Timeout waiting for SSH`, or the
+provisioner aborts while installing ROCm).
+
+## Apply the patch
+
+```bash
+cd gem5-resources
+git apply ../scripts/patches/0001-user-data-cn-mirror.patch
+```
+
+Revert:
+
+```bash
+cd gem5-resources
+git apply -R ../scripts/patches/0001-user-data-cn-mirror.patch
+```
+
+To use a different mirror, edit the URI in the patch and re-apply.

--- a/docs/en/cosim-technical-notes.md
+++ b/docs/en/cosim-technical-notes.md
@@ -348,7 +348,5 @@ screen -S qemu-cosim -X stuff 'modprobe amdgpu ip_block_mask=0x67 discovery=2 ra
   docker run --rm -v "$PWD:/gem5" -w /gem5 gem5-run:local \
     sh -c 'rm -f build/VEGA_X86/dev/amdgpu/<file>.o'
   docker run --rm -v "$PWD:/gem5" -w /gem5 \
-    -e PYTHONPATH=/usr/lib/python3.12/lib-dynload \
-    gem5-run:local scons build/VEGA_X86/gem5.opt -j1 \
-    GOLD_LINKER=True --linker=gold
+    gem5-run:local scons build/VEGA_X86/gem5.opt -j1
   ```

--- a/docs/en/cosim-usage-guide.md
+++ b/docs/en/cosim-usage-guide.md
@@ -78,9 +78,8 @@ cd /home/zevorn/cosim/gem5
 # Build using the gpu-fs image (amd64, includes all dependencies)
 docker run --rm \
     -v "$(pwd):/gem5" -w /gem5 \
-    -e PYTHONPATH=/usr/lib/python3.12/lib-dynload \
-    ghcr.io/gem5/gpu-fs:latest \
-    bash -c "scons build/VEGA_X86/gem5.opt -j4 GOLD_LINKER=True --linker=gold 2>&1"
+    gem5-run:local \
+    scons build/VEGA_X86/gem5.opt -j4
 ```
 
 > **Note:** Reduce parallelism (`-j1` or `-j2`) if running out of memory. Using the gold linker reduces memory usage during the linking stage.

--- a/docs/zh/build-disk-china-mirror.md
+++ b/docs/zh/build-disk-china-mirror.md
@@ -1,0 +1,25 @@
+[English](../en/build-disk-china-mirror.md)
+
+# 国内构建磁盘镜像加速补丁
+
+## 问题
+
+国内直连环境跑 `./scripts/run_mi300x_fs.sh build-disk` 时，VM 内 `apt`
+会从 `us.archive.ubuntu.com` 拉包，常因网络波动挂住（Packer
+`Timeout waiting for SSH` 或 provisioner 装 ROCm 时退出）。
+
+## 应用补丁
+
+```bash
+cd gem5-resources
+git apply ../scripts/patches/0001-user-data-cn-mirror.patch
+```
+
+回滚：
+
+```bash
+cd gem5-resources
+git apply -R ../scripts/patches/0001-user-data-cn-mirror.patch
+```
+
+切换其他镜像源：修改 patch 里的 URI 后重新 apply。

--- a/docs/zh/cosim-technical-notes.md
+++ b/docs/zh/cosim-technical-notes.md
@@ -348,7 +348,5 @@ screen -S qemu-cosim -X stuff 'modprobe amdgpu ip_block_mask=0x67 discovery=2 ra
   docker run --rm -v "$PWD:/gem5" -w /gem5 gem5-run:local \
     sh -c 'rm -f build/VEGA_X86/dev/amdgpu/<file>.o'
   docker run --rm -v "$PWD:/gem5" -w /gem5 \
-    -e PYTHONPATH=/usr/lib/python3.12/lib-dynload \
-    gem5-run:local scons build/VEGA_X86/gem5.opt -j1 \
-    GOLD_LINKER=True --linker=gold
+    gem5-run:local scons build/VEGA_X86/gem5.opt -j1
   ```

--- a/docs/zh/cosim-usage-guide.md
+++ b/docs/zh/cosim-usage-guide.md
@@ -78,9 +78,8 @@ cd /home/zevorn/cosim/gem5
 # 使用 gpu-fs 镜像编译（amd64，包含所有依赖）
 docker run --rm \
     -v "$(pwd):/gem5" -w /gem5 \
-    -e PYTHONPATH=/usr/lib/python3.12/lib-dynload \
-    ghcr.io/gem5/gpu-fs:latest \
-    bash -c "scons build/VEGA_X86/gem5.opt -j4 GOLD_LINKER=True --linker=gold 2>&1"
+    gem5-run:local \
+    scons build/VEGA_X86/gem5.opt -j4
 ```
 
 > **注意：** 内存不足时降低并行度（`-j1` 或 `-j2`）。使用 gold linker 可减少链接阶段内存占用。

--- a/scripts/patches/0001-user-data-cn-mirror.patch
+++ b/scripts/patches/0001-user-data-cn-mirror.patch
@@ -1,0 +1,27 @@
+# Patch for: gem5-resources/src/x86-ubuntu-gpu-ml/http/user-data
+# Purpose: Use Aliyun mirror instead of US archive for apt during autoinstall.
+# Scope:   gem5-resources submodule only. DO NOT commit to gem5-resources upstream.
+# Apply:   cd gem5-resources && git apply ../scripts/patches/0001-user-data-cn-mirror.patch
+# Revert:  cd gem5-resources && git apply -R ../scripts/patches/0001-user-data-cn-mirror.patch
+# Note:    Tsinghua (TUNA) was tried first but returned 403 to apt inside the VM
+#          (reproducible; host curl to the same URL is 200). Aliyun works.
+# See:     docs/zh/build-disk-china-mirror.md  (docs/en/build-disk-china-mirror.md)
+
+diff --git a/src/x86-ubuntu-gpu-ml/http/user-data b/src/x86-ubuntu-gpu-ml/http/user-data
+--- a/src/x86-ubuntu-gpu-ml/http/user-data
++++ b/src/x86-ubuntu-gpu-ml/http/user-data
+@@ -3,12 +3,12 @@ autoinstall:
+   apt:
+     disable_components: []
+-    geoip: true
++    geoip: false
+     preserve_sources_list: false
+     primary:
+     - arches:
+       - amd64
+       - i386
+-      uri: http://us.archive.ubuntu.com/ubuntu
++      uri: https://mirrors.aliyun.com/ubuntu
+     - arches:
+       - default
+       uri: http://ports.ubuntu.com/ubuntu-ports

--- a/scripts/run_mi300x_fs.sh
+++ b/scripts/run_mi300x_fs.sh
@@ -41,6 +41,10 @@ QEMU_DIR="${COSIM_DIR}/qemu"
 QEMU_BUILD_DIR="${QEMU_DIR}/build"
 QEMU_BIN="${QEMU_BUILD_DIR}/qemu-system-x86_64"
 
+# Logs
+LOGS_DIR="${COSIM_DIR}/logs"
+BUILD_DISK_LOG="${LOGS_DIR}/build-disk.log"
+
 # Docker images
 GEM5_BUILD_IMAGE="gem5-build:local"
 GPU_APP_BUILD_IMAGE="${GPU_APP_BUILD_IMAGE:-ghcr.io/gem5/gpu-fs}"
@@ -196,12 +200,16 @@ build_disk_image() {
     fi
 
     info "Using QEMU: $QEMU_BIN"
+    info "Build log:  $BUILD_DISK_LOG"
+
+    mkdir -p "$LOGS_DIR"
     cd "${RESOURCES_DIR}/src/x86-ubuntu-gpu-ml"
     local proxy_args=()
     if [ -n "${https_proxy:-}" ]; then
         proxy_args+=(-var "http_proxy=${https_proxy}")
     fi
-    PATH="${QEMU_BUILD_DIR}:$PATH" ./build.sh -var "qemu_path=${QEMU_BIN}" "${proxy_args[@]}"
+    PATH="${QEMU_BUILD_DIR}:$PATH" ./build.sh -var "qemu_path=${QEMU_BIN}" "${proxy_args[@]}" \
+        2>&1 | awk '{ print strftime("[%H:%M:%S]"), $0; fflush() }' | tee "$BUILD_DISK_LOG"
 
     [ -f "$DISK_IMAGE" ] || error "Disk image build failed"
     info "Disk image: $DISK_IMAGE"

--- a/scripts/run_mi300x_fs.sh
+++ b/scripts/run_mi300x_fs.sh
@@ -182,8 +182,8 @@ build_disk_image() {
     info "Building disk image (Ubuntu 22.04 + ROCm)..."
     info "This takes ~30 min and needs ~60GB disk space"
 
-    command -v qemu-system-x86_64 >/dev/null || \
-        error "qemu-system-x86_64 not found. Install: sudo apt install qemu-system-x86"
+    [ -x "$QEMU_BIN" ] || \
+        error "Project QEMU not built: $QEMU_BIN. Run: $0 build-qemu"
     command -v unzip >/dev/null || \
         error "unzip not found. Install: sudo apt install unzip"
     check_kvm || error "KVM required for disk image build"
@@ -195,14 +195,13 @@ build_disk_image() {
         [[ ! $REPLY =~ ^[Yy]$ ]] && return 0
     fi
 
+    info "Using QEMU: $QEMU_BIN"
     cd "${RESOURCES_DIR}/src/x86-ubuntu-gpu-ml"
-    local qemu_bin
-    qemu_bin="$(command -v qemu-system-x86_64)"
     local proxy_args=()
     if [ -n "${https_proxy:-}" ]; then
         proxy_args+=(-var "http_proxy=${https_proxy}")
     fi
-    ./build.sh -var "qemu_path=${qemu_bin}" "${proxy_args[@]}"
+    PATH="${QEMU_BUILD_DIR}:$PATH" ./build.sh -var "qemu_path=${QEMU_BIN}" "${proxy_args[@]}"
 
     [ -f "$DISK_IMAGE" ] || error "Disk image build failed"
     info "Disk image: $DISK_IMAGE"


### PR DESCRIPTION
## Summary
- f03f4de — build gem5 via `gem5-run:local` (add json-c dep)
- 9c6e279 — build-disk uses project-built QEMU
- 50c0406 — build-disk logs output with timestamps
- ed5dd2d — document china mirror patch for disk image build
- f36df3b — drop PYTHONPATH override that made scons silently skip `gem5.opt`

## Test plan
- [x] Cosim launches successfully following README Option B (manual) flow