### PR TITLE
feat(scripts): deterministic state cleanup for repeated cosim runs

### DIFF
--- a/scripts/cosim_launch.sh
+++ b/scripts/cosim_launch.sh
@@ -360,11 +360,15 @@ parse_size_bytes() {
     local num="${val%%[GgMmKkTt]*}"
     local suffix="${val##*[0-9]}"
     case "${suffix,,}" in
-        gib|g) echo $((num * 1024 * 1024 * 1024)) ;;
-        mib|m) echo $((num * 1024 * 1024)) ;;
-        kib|k) echo $((num * 1024)) ;;
-        tib|t) echo $((num * 1024 * 1024 * 1024 * 1024)) ;;
-        *)     echo "$num" ;;
+        gib|g)  echo $((num * 1024 * 1024 * 1024)) ;;
+        gb)     echo $((num * 1000 * 1000 * 1000)) ;;
+        mib|m)  echo $((num * 1024 * 1024)) ;;
+        mb)     echo $((num * 1000 * 1000)) ;;
+        kib|k)  echo $((num * 1024)) ;;
+        kb)     echo $((num * 1000)) ;;
+        tib|t)  echo $((num * 1024 * 1024 * 1024 * 1024)) ;;
+        tb)     echo $((num * 1000 * 1000 * 1000 * 1000)) ;;
+        *)      echo "$num" ;;
     esac
 }
 

--- a/scripts/cosim_launch.sh
+++ b/scripts/cosim_launch.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COSIM_DIR="$(dirname "$SCRIPT_DIR")"
 
-# shellcheck source=cosim_lib.sh
+# shellcheck disable=SC1091
 source "${SCRIPT_DIR}/cosim_lib.sh"
 
 # ---- Run-ID ----
@@ -221,6 +221,7 @@ manifest_add "artifact" "directory" "$ARTIFACT_DIR"
 
 # ---- Cleanup handler ----
 
+# shellcheck disable=SC2317
 cleanup() {
     local exit_code="${1:-$?}"
     echo ""

--- a/scripts/cosim_launch.sh
+++ b/scripts/cosim_launch.sh
@@ -19,10 +19,20 @@
 
 set -euo pipefail
 
-# ---- Path defaults ----
+# ---- Shared library ----
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COSIM_DIR="$(dirname "$SCRIPT_DIR")"
+
+# shellcheck source=cosim_lib.sh
+source "${SCRIPT_DIR}/cosim_lib.sh"
+
+# ---- Run-ID ----
+
+COSIM_RUN_ID="${COSIM_RUN_ID:-$(generate_run_id)}"
+export COSIM_RUN_ID
+
+# ---- Path defaults ----
 GEM5_DIR="${COSIM_DIR}/gem5"
 RESOURCES_DIR="${COSIM_DIR}/gem5-resources"
 
@@ -30,16 +40,16 @@ GEM5_BIN="${GEM5_DIR}/build/VEGA_X86/gem5.opt"
 # shellcheck disable=SC2034
 GEM5_CONFIG="${GEM5_DIR}/configs/example/gpufs/mi300_cosim.py"
 GEM5_DOCKER_IMAGE="${GEM5_DOCKER_IMAGE:-gem5-run:local}"
-GEM5_CONTAINER="gem5-cosim"
+GEM5_CONTAINER="$(cosim_container_name "$COSIM_RUN_ID")"
 
 QEMU_BIN="${COSIM_DIR}/qemu/build/qemu-system-x86_64"
 DISK_IMAGE="${RESOURCES_DIR}/src/x86-ubuntu-gpu-ml/disk-image/x86-ubuntu-rocm70"
 KERNEL="${RESOURCES_DIR}/src/x86-ubuntu-gpu-ml/vmlinux-rocm70"
 GPU_ROM="${RESOURCES_DIR}/src/x86-ubuntu-gpu-ml/files/mi300.rom"
 
-SOCKET_PATH="/tmp/gem5-mi300x.sock"
-SHMEM_PATH="/mi300x-vram"
-SHMEM_HOST_PATH="/cosim-guest-ram"
+SOCKET_PATH="/tmp/gem5-mi300x-${COSIM_RUN_ID}.sock"
+SHMEM_PATH="/mi300x-vram-${COSIM_RUN_ID}"
+SHMEM_HOST_PATH="/cosim-guest-ram-${COSIM_RUN_ID}"
 
 HOST_MEM="8G"
 HOST_CPUS="4"
@@ -51,6 +61,14 @@ QEMU_TRACE=""
 SHARE_DIR=""
 COSIM_BACKEND="vfio-user"
 NUM_GPUS="1"
+FORCE_CLEAN=""
+FORCE_CLEAN_CONFIRM=""
+
+SESSION_DIR="/tmp/cosim-${COSIM_RUN_ID}.session"
+SCREEN_LOG="/tmp/cosim-${COSIM_RUN_ID}.log"
+ARTIFACT_DIR="${COSIM_DIR}/artifacts/standalone/${COSIM_RUN_ID}"
+COSIM_FAILURE_CATEGORY=""
+COSIM_SECONDARY_STATUS=""
 
 # ---- Colors ----
 
@@ -90,6 +108,8 @@ Options:
   --cosim-backend MODE    vfio-user (default) or legacy
   --num-gpus N            Number of GPU instances (default: 1)
   --timeout SECS          gem5 init timeout (default: 120)
+  --force-clean           List orphaned cosim resources (dry-run)
+  --confirm               With --force-clean, actually delete orphans
   -h, --help              Show this help
 EOF
     exit 0
@@ -113,10 +133,25 @@ while [[ $# -gt 0 ]]; do
         --cosim-backend) COSIM_BACKEND="$2";   shift 2 ;;
         --num-gpus)      NUM_GPUS="$2";         shift 2 ;;
         --timeout)       GEM5_TIMEOUT="$2";     shift 2 ;;
+        --force-clean)   FORCE_CLEAN=1;         shift ;;
+        --confirm)       FORCE_CLEAN_CONFIRM=1; shift ;;
         -h|--help)       usage ;;
         *)               echo "Unknown option: $1"; usage ;;
     esac
 done
+
+# Handle --force-clean mode
+if [[ -n "$FORCE_CLEAN" ]]; then
+    info "Force-clean mode (run-ID: $COSIM_RUN_ID)"
+    if [[ -n "$FORCE_CLEAN_CONFIRM" ]]; then
+        warn "Deleting orphaned cosim resources..."
+        force_clean_orphans "true"
+    else
+        info "Dry-run: listing orphaned cosim resources..."
+        force_clean_orphans "false"
+    fi
+    exit 0
+fi
 
 # ---- Multi-GPU validation ----
 
@@ -170,29 +205,65 @@ docker info >/dev/null 2>&1 || error "Docker not running"
 docker image inspect "$GEM5_DOCKER_IMAGE" >/dev/null 2>&1 || \
     error "Docker image '$GEM5_DOCKER_IMAGE' not found.\n  Build: cd scripts && docker build -t gem5-run:local -f Dockerfile.run ."
 
+# ---- Session and manifest setup ----
+
+mkdir -p "$SESSION_DIR"
+manifest_init "$SESSION_DIR"
+
+manifest_add "runtime" "container" "$GEM5_CONTAINER"
+manifest_add "runtime" "shmem" "$SHMEM_HOST_FILE"
+for ((g=0; g<NUM_GPUS; g++)); do
+    manifest_add "runtime" "shmem" "$(gpu_shmem_file "$g")"
+    manifest_add "runtime" "socket" "$(gpu_socket_path "$g")"
+done
+manifest_add "runtime" "directory" "$SESSION_DIR"
+manifest_add "artifact" "directory" "$ARTIFACT_DIR"
+
 # ---- Cleanup handler ----
 
 cleanup() {
+    local exit_code="${1:-$?}"
     echo ""
-    info "Shutting down co-simulation..."
-    docker rm -f "$GEM5_CONTAINER" >/dev/null 2>&1 || true
-    rm -f "$SHMEM_HOST_FILE" 2>/dev/null || true
-    for ((g=0; g<NUM_GPUS; g++)); do
-        rm -f "$(gpu_shmem_file "$g")" 2>/dev/null || true
-        rm -f "$(gpu_socket_path "$g")" 2>/dev/null || true
-    done
-    info "Done."
+
+    # If runner signaled normal completion, treat as test_pass regardless
+    if [[ -f "/tmp/cosim-test-done-${COSIM_RUN_ID}" ]]; then
+        rm -f "/tmp/cosim-test-done-${COSIM_RUN_ID}"
+        COSIM_FAILURE_CATEGORY="$COSIM_CAT_TEST_PASS"
+    elif [[ -z "$COSIM_FAILURE_CATEGORY" ]]; then
+        if [[ "$exit_code" -eq 0 ]]; then
+            COSIM_FAILURE_CATEGORY="$COSIM_CAT_TEST_PASS"
+        else
+            COSIM_FAILURE_CATEGORY="$COSIM_CAT_INFRA_UNKNOWN"
+        fi
+    fi
+
+    # Write category to a file outside session dir (session dir is deleted during cleanup)
+    echo "$COSIM_FAILURE_CATEGORY" > "/tmp/cosim-launcher-category-${COSIM_RUN_ID}.txt" 2>/dev/null || true
+
+    if [[ "$COSIM_FAILURE_CATEGORY" != "$COSIM_CAT_TEST_PASS" ]]; then
+        info "Capturing diagnostic artifacts (category: $COSIM_FAILURE_CATEGORY)..."
+        capture_artifacts "$ARTIFACT_DIR" "$GEM5_CONTAINER" "$SCREEN_LOG" \
+            "$COSIM_RUN_ID" "$COSIM_FAILURE_CATEGORY"
+    fi
+
+    info "Shutting down co-simulation (run-ID: $COSIM_RUN_ID)..."
+    cleanup_from_manifest "$GEM5_CONTAINER"
+
+    if verify_cleanup 10 "$GEM5_CONTAINER"; then
+        info "Teardown verified."
+    else
+        COSIM_SECONDARY_STATUS="$COSIM_CAT_CLEANUP_FAIL"
+        warn "Teardown verification failed: some resources may remain."
+    fi
+
+    info "Run: $COSIM_RUN_ID | Category: $COSIM_FAILURE_CATEGORY${COSIM_SECONDARY_STATUS:+ | Secondary: $COSIM_SECONDARY_STATUS}"
 }
-trap cleanup EXIT INT TERM
+trap 'cleanup' EXIT
+trap 'COSIM_FAILURE_CATEGORY="$COSIM_CAT_INTERRUPT"; exit 130' INT TERM
 
-# ---- Clean up stale state ----
+# ---- Preflight audit ----
 
-docker rm -f "$GEM5_CONTAINER" >/dev/null 2>&1 || true
-rm -f "$SHMEM_HOST_FILE" 2>/dev/null || true
-for ((g=0; g<NUM_GPUS; g++)); do
-    rm -f "$(gpu_shmem_file "$g")" 2>/dev/null || true
-    rm -f "$(gpu_socket_path "$g")" 2>/dev/null || true
-done
+run_preflight_audit | tee "${SESSION_DIR}/preflight.log"
 
 # ==================================================================
 # Step 1: Start gem5 in Docker
@@ -260,18 +331,58 @@ while true; do
     # Check container still running
     if [[ "$(docker inspect -f '{{.State.Running}}' "$GEM5_CONTAINER" 2>/dev/null)" != "true" ]]; then
         echo ""
+        COSIM_FAILURE_CATEGORY="$COSIM_CAT_GEM5_EXIT"
         error "gem5 container exited unexpectedly. Logs:\n$(docker logs "$GEM5_CONTAINER" 2>&1 | tail -20)"
     fi
 
     sleep 2
     ELAPSED=$((ELAPSED + 2))
     if [[ $ELAPSED -ge $GEM5_TIMEOUT ]]; then
+        COSIM_FAILURE_CATEGORY="$COSIM_CAT_GEM5_INIT_TIMEOUT"
         error "gem5 did not become ready in ${GEM5_TIMEOUT}s.\n  Logs: docker logs $GEM5_CONTAINER"
     fi
 
     # Progress indicator
     if (( ELAPSED % 10 == 0 )); then
         echo -n "."
+    fi
+done
+
+# ==================================================================
+# Step 2.5: Pre-launch health check
+# ==================================================================
+
+step "Running pre-launch health check..."
+
+parse_size_bytes() {
+    local val="$1"
+    local num="${val%%[GgMmKkTt]*}"
+    local suffix="${val##*[0-9]}"
+    case "${suffix,,}" in
+        gib|g) echo $((num * 1024 * 1024 * 1024)) ;;
+        mib|m) echo $((num * 1024 * 1024)) ;;
+        kib|k) echo $((num * 1024)) ;;
+        tib|t) echo $((num * 1024 * 1024 * 1024 * 1024)) ;;
+        *)     echo "$num" ;;
+    esac
+}
+
+EXPECTED_VRAM_BYTES="$(parse_size_bytes "$VRAM_SIZE")"
+EXPECTED_RAM_BYTES="$(parse_size_bytes "$HOST_MEM")"
+
+HEALTH_MSG=""
+for ((g=0; g<NUM_GPUS; g++)); do
+    if HEALTH_MSG="$(check_readiness \
+            "$(gpu_socket_path "$g")" \
+            "$(gpu_shmem_file "$g")" \
+            "$SHMEM_HOST_FILE" \
+            "$GEM5_CONTAINER" \
+            "$EXPECTED_VRAM_BYTES" \
+            "$EXPECTED_RAM_BYTES")"; then
+        info "Health check GPU $g passed."
+    else
+        COSIM_FAILURE_CATEGORY="$COSIM_CAT_READINESS_FAIL"
+        error "Pre-launch health check failed (GPU $g): $HEALTH_MSG"
     fi
 done
 
@@ -285,6 +396,7 @@ VRAM_BYTES=$((16 * 1024 * 1024 * 1024))
 step "Starting QEMU (Q35 + KVM, backend=$COSIM_BACKEND)..."
 
 echo "============================================================"
+echo "  Run-ID:     $COSIM_RUN_ID"
 echo "  Machine:    Q35 + KVM"
 echo "  Backend:    $COSIM_BACKEND"
 echo "  Num GPUs:   $NUM_GPUS"
@@ -364,5 +476,11 @@ if [[ -n "$SHARE_DIR" ]]; then
     info "Sharing host dir: $SHARE_DIR (mount: mount -t 9p -o trans=virtio cosim_share /mnt)"
 fi
 
-# Run QEMU in foreground with interactive serial console
-exec "${QEMU_CMD[@]}"
+# Run QEMU in foreground — do NOT exec, so the EXIT trap runs on QEMU exit
+if "${QEMU_CMD[@]}"; then
+    QEMU_RC=0
+else
+    QEMU_RC=$?
+    COSIM_FAILURE_CATEGORY="${COSIM_FAILURE_CATEGORY:-$COSIM_CAT_QEMU_EXIT}"
+fi
+exit $QEMU_RC

--- a/scripts/cosim_lib.sh
+++ b/scripts/cosim_lib.sh
@@ -223,25 +223,28 @@ force_clean_orphans() {
         fi
     done < <(docker ps -a --filter "name=gem5-cosim-" --filter "status=exited" --filter "status=dead" --filter "status=created" --format '{{.Names}}' 2>/dev/null)
 
-    _extract_run_id() {
+    local -a _active_rids=()
+    local _cname
+    while IFS= read -r _cname; do
+        [[ -z "$_cname" ]] && continue
+        _active_rids+=("${_cname#gem5-cosim-}")
+    done < <(docker ps --filter "name=gem5-cosim-" --format '{{.Names}}' 2>/dev/null)
+
+    _resource_is_active() {
         local name="$1"
-        if [[ "$name" =~ ^([0-9]{8}-[0-9]{6}-[0-9a-f]+) ]]; then
-            echo "${BASH_REMATCH[1]}"
-        fi
+        local rid
+        for rid in "${_active_rids[@]+"${_active_rids[@]}"}"; do
+            if [[ "$name" == *"$rid"* ]]; then
+                return 0
+            fi
+        done
+        return 1
     }
 
-    _is_run_active() {
-        local rid="$1"
-        [[ -n "$rid" ]] || return 1
-        local cname="gem5-cosim-${rid}"
-        [[ "$(docker inspect -f '{{.State.Running}}' "$cname" 2>/dev/null)" == "true" ]]
-    }
-
-    local f rid
+    local f
     for f in /tmp/gem5-mi300x-*.sock; do
         [[ -e "$f" ]] || continue
-        rid="$(_extract_run_id "${f#/tmp/gem5-mi300x-}")"
-        if [[ -n "$rid" ]] && _is_run_active "$rid"; then
+        if _resource_is_active "$f"; then
             echo "  active socket (skipped): $f"
             continue
         fi
@@ -254,12 +257,7 @@ force_clean_orphans() {
 
     for f in /dev/shm/mi300x-vram /dev/shm/mi300x-vram-* /dev/shm/cosim-guest-ram /dev/shm/cosim-guest-ram-*; do
         [[ -e "$f" ]] || continue
-        rid=""
-        case "$f" in
-            /dev/shm/mi300x-vram-*)      rid="$(_extract_run_id "${f#/dev/shm/mi300x-vram-}")" ;;
-            /dev/shm/cosim-guest-ram-*)   rid="$(_extract_run_id "${f#/dev/shm/cosim-guest-ram-}")" ;;
-        esac
-        if [[ -n "$rid" ]] && _is_run_active "$rid"; then
+        if _resource_is_active "$f"; then
             echo "  active shmem (skipped): $f"
             continue
         fi

--- a/scripts/cosim_lib.sh
+++ b/scripts/cosim_lib.sh
@@ -223,9 +223,23 @@ force_clean_orphans() {
         fi
     done < <(docker ps -a --filter "name=gem5-cosim-" --filter "status=exited" --filter "status=dead" --filter "status=created" --format '{{.Names}}' 2>/dev/null)
 
-    local f
+    _is_run_active() {
+        local rid="$1"
+        [[ -n "$rid" ]] || return 1
+        local cname="gem5-cosim-${rid}"
+        [[ "$(docker inspect -f '{{.State.Running}}' "$cname" 2>/dev/null)" == "true" ]]
+    }
+
+    local f rid
     for f in /tmp/gem5-mi300x-*.sock; do
         [[ -e "$f" ]] || continue
+        rid="${f#/tmp/gem5-mi300x-}"
+        rid="${rid%.sock}"
+        rid="${rid%%-[0-9]*}"
+        if _is_run_active "$rid"; then
+            echo "  active socket (skipped): $f"
+            continue
+        fi
         echo "  orphan socket: $f"
         found=1
         if [[ "$confirm" == "true" ]]; then
@@ -235,6 +249,16 @@ force_clean_orphans() {
 
     for f in /dev/shm/mi300x-vram /dev/shm/mi300x-vram-* /dev/shm/cosim-guest-ram /dev/shm/cosim-guest-ram-*; do
         [[ -e "$f" ]] || continue
+        rid=""
+        case "$f" in
+            /dev/shm/mi300x-vram-*)      rid="${f#/dev/shm/mi300x-vram-}" ;;
+            /dev/shm/cosim-guest-ram-*)   rid="${f#/dev/shm/cosim-guest-ram-}" ;;
+        esac
+        rid="${rid%%-[0-9]*}"
+        if [[ -n "$rid" ]] && _is_run_active "$rid"; then
+            echo "  active shmem (skipped): $f"
+            continue
+        fi
         echo "  orphan shmem: $f"
         found=1
         if [[ "$confirm" == "true" ]]; then

--- a/scripts/cosim_lib.sh
+++ b/scripts/cosim_lib.sh
@@ -65,20 +65,20 @@ cosim_artifact_dir() {
     echo "${cosim_dir}/artifacts/${operator}/${run_id}"
 }
 
-# ---- Failure Taxonomy ----
+# ---- Failure Taxonomy (exported for use by sourcing scripts) ----
 
-readonly COSIM_CAT_TEST_PASS="test_pass"
-readonly COSIM_CAT_TEST_FAIL="test_fail"
-readonly COSIM_CAT_TEST_TIMEOUT="test_timeout"
-readonly COSIM_CAT_BOOT_TIMEOUT="boot_timeout"
-readonly COSIM_CAT_GEM5_INIT_TIMEOUT="gem5_init_timeout"
-readonly COSIM_CAT_GEM5_EXIT="gem5_exit"
-readonly COSIM_CAT_QEMU_EXIT="qemu_exit"
-readonly COSIM_CAT_READINESS_FAIL="readiness_fail"
-readonly COSIM_CAT_STALE_CONFLICT="stale_conflict"
-readonly COSIM_CAT_INTERRUPT="interrupt"
-readonly COSIM_CAT_CLEANUP_FAIL="cleanup_fail"
-readonly COSIM_CAT_INFRA_UNKNOWN="infra_unknown"
+export COSIM_CAT_TEST_PASS="test_pass"
+export COSIM_CAT_TEST_FAIL="test_fail"
+export COSIM_CAT_TEST_TIMEOUT="test_timeout"
+export COSIM_CAT_BOOT_TIMEOUT="boot_timeout"
+export COSIM_CAT_GEM5_INIT_TIMEOUT="gem5_init_timeout"
+export COSIM_CAT_GEM5_EXIT="gem5_exit"
+export COSIM_CAT_QEMU_EXIT="qemu_exit"
+export COSIM_CAT_READINESS_FAIL="readiness_fail"
+export COSIM_CAT_STALE_CONFLICT="stale_conflict"
+export COSIM_CAT_INTERRUPT="interrupt"
+export COSIM_CAT_CLEANUP_FAIL="cleanup_fail"
+export COSIM_CAT_INFRA_UNKNOWN="infra_unknown"
 
 is_infra_failure() {
     local category="$1"
@@ -143,7 +143,7 @@ capture_artifacts() {
 
     ls -la /dev/shm/ > "${artifact_dir}/devshm-listing.txt" 2>&1 || true
     ls -la /tmp/gem5-mi300x*.sock > "${artifact_dir}/socket-listing.txt" 2>&1 || true
-    ps aux | grep -E '(gem5|qemu)' | grep -v grep > "${artifact_dir}/process-snapshot.txt" 2>&1 || true
+    pgrep -af '(gem5|qemu)' > "${artifact_dir}/process-snapshot.txt" 2>&1 || true
     docker ps -a --filter "name=gem5-cosim" > "${artifact_dir}/docker-ps.txt" 2>&1 || true
 }
 
@@ -243,14 +243,13 @@ force_clean_orphans() {
     done
 
     # Legacy un-namespaced resources
-    for f in /tmp/gem5-mi300x.sock; do
-        [[ -e "$f" ]] || continue
-        echo "  orphan legacy socket: $f"
+    if [[ -e /tmp/gem5-mi300x.sock ]]; then
+        echo "  orphan legacy socket: /tmp/gem5-mi300x.sock"
         found=1
         if [[ "$confirm" == "true" ]]; then
-            rm -f "$f" 2>/dev/null || true
+            rm -f /tmp/gem5-mi300x.sock 2>/dev/null || true
         fi
-    done
+    fi
     if docker ps -a --format '{{.Names}}' 2>/dev/null | grep -qx 'gem5-cosim'; then
         echo "  orphan legacy container: gem5-cosim"
         found=1

--- a/scripts/cosim_lib.sh
+++ b/scripts/cosim_lib.sh
@@ -221,7 +221,7 @@ force_clean_orphans() {
         if [[ "$confirm" == "true" ]]; then
             docker rm -f "$c" >/dev/null 2>&1 || true
         fi
-    done < <(docker ps -a --filter "name=gem5-cosim-" --format '{{.Names}}' 2>/dev/null)
+    done < <(docker ps -a --filter "name=gem5-cosim-" --filter "status=exited" --filter "status=dead" --filter "status=created" --format '{{.Names}}' 2>/dev/null)
 
     local f
     for f in /tmp/gem5-mi300x-*.sock; do
@@ -250,7 +250,7 @@ force_clean_orphans() {
             rm -f /tmp/gem5-mi300x.sock 2>/dev/null || true
         fi
     fi
-    if docker ps -a --format '{{.Names}}' 2>/dev/null | grep -qx 'gem5-cosim'; then
+    if docker ps -a --filter "status=exited" --filter "status=dead" --filter "status=created" --format '{{.Names}}' 2>/dev/null | grep -qx 'gem5-cosim'; then
         echo "  orphan legacy container: gem5-cosim"
         found=1
         if [[ "$confirm" == "true" ]]; then

--- a/scripts/cosim_lib.sh
+++ b/scripts/cosim_lib.sh
@@ -223,6 +223,13 @@ force_clean_orphans() {
         fi
     done < <(docker ps -a --filter "name=gem5-cosim-" --filter "status=exited" --filter "status=dead" --filter "status=created" --format '{{.Names}}' 2>/dev/null)
 
+    _extract_run_id() {
+        local name="$1"
+        if [[ "$name" =~ ^([0-9]{8}-[0-9]{6}-[0-9a-f]+) ]]; then
+            echo "${BASH_REMATCH[1]}"
+        fi
+    }
+
     _is_run_active() {
         local rid="$1"
         [[ -n "$rid" ]] || return 1
@@ -233,10 +240,8 @@ force_clean_orphans() {
     local f rid
     for f in /tmp/gem5-mi300x-*.sock; do
         [[ -e "$f" ]] || continue
-        rid="${f#/tmp/gem5-mi300x-}"
-        rid="${rid%.sock}"
-        rid="${rid%%-[0-9]*}"
-        if _is_run_active "$rid"; then
+        rid="$(_extract_run_id "${f#/tmp/gem5-mi300x-}")"
+        if [[ -n "$rid" ]] && _is_run_active "$rid"; then
             echo "  active socket (skipped): $f"
             continue
         fi
@@ -251,10 +256,9 @@ force_clean_orphans() {
         [[ -e "$f" ]] || continue
         rid=""
         case "$f" in
-            /dev/shm/mi300x-vram-*)      rid="${f#/dev/shm/mi300x-vram-}" ;;
-            /dev/shm/cosim-guest-ram-*)   rid="${f#/dev/shm/cosim-guest-ram-}" ;;
+            /dev/shm/mi300x-vram-*)      rid="$(_extract_run_id "${f#/dev/shm/mi300x-vram-}")" ;;
+            /dev/shm/cosim-guest-ram-*)   rid="$(_extract_run_id "${f#/dev/shm/cosim-guest-ram-}")" ;;
         esac
-        rid="${rid%%-[0-9]*}"
         if [[ -n "$rid" ]] && _is_run_active "$rid"; then
             echo "  active shmem (skipped): $f"
             continue

--- a/scripts/cosim_lib.sh
+++ b/scripts/cosim_lib.sh
@@ -1,0 +1,340 @@
+#!/bin/bash
+# Shared library for cosim infrastructure: run-ID generation, resource path
+# computation, failure taxonomy, resource manifest, and diagnostic utilities.
+
+# ---- Run-ID Generation ----
+
+generate_run_id() {
+    local ts
+    ts="$(date +%Y%m%d-%H%M%S)"
+    local rand
+    rand="$(head -c4 /dev/urandom | xxd -p)"
+    echo "${ts}-${rand}"
+}
+
+# ---- Resource Path Computation ----
+
+cosim_container_name() {
+    local run_id="$1"
+    echo "gem5-cosim-${run_id}"
+}
+
+cosim_socket_path() {
+    local run_id="$1"
+    local gpu_id="${2:-0}"
+    local num_gpus="${3:-1}"
+    if [[ "$num_gpus" -eq 1 ]]; then
+        echo "/tmp/gem5-mi300x-${run_id}.sock"
+    else
+        echo "/tmp/gem5-mi300x-${run_id}-${gpu_id}.sock"
+    fi
+}
+
+cosim_vram_shmem_path() {
+    local run_id="$1"
+    local gpu_id="${2:-0}"
+    local num_gpus="${3:-1}"
+    if [[ "$num_gpus" -eq 1 ]]; then
+        echo "/dev/shm/mi300x-vram-${run_id}"
+    else
+        echo "/dev/shm/mi300x-vram-${run_id}-${gpu_id}"
+    fi
+}
+
+cosim_guest_ram_shmem_path() {
+    local run_id="$1"
+    echo "/dev/shm/cosim-guest-ram-${run_id}"
+}
+
+cosim_session_dir() {
+    local run_id="$1"
+    local session_name="${2:-cosim}"
+    echo "/tmp/${session_name}-${run_id}.session"
+}
+
+cosim_screen_log() {
+    local run_id="$1"
+    local session_name="${2:-cosim}"
+    echo "/tmp/${session_name}-${run_id}.log"
+}
+
+cosim_artifact_dir() {
+    local cosim_dir="$1"
+    local operator="$2"
+    local run_id="$3"
+    echo "${cosim_dir}/artifacts/${operator}/${run_id}"
+}
+
+# ---- Failure Taxonomy ----
+
+readonly COSIM_CAT_TEST_PASS="test_pass"
+readonly COSIM_CAT_TEST_FAIL="test_fail"
+readonly COSIM_CAT_TEST_TIMEOUT="test_timeout"
+readonly COSIM_CAT_BOOT_TIMEOUT="boot_timeout"
+readonly COSIM_CAT_GEM5_INIT_TIMEOUT="gem5_init_timeout"
+readonly COSIM_CAT_GEM5_EXIT="gem5_exit"
+readonly COSIM_CAT_QEMU_EXIT="qemu_exit"
+readonly COSIM_CAT_READINESS_FAIL="readiness_fail"
+readonly COSIM_CAT_STALE_CONFLICT="stale_conflict"
+readonly COSIM_CAT_INTERRUPT="interrupt"
+readonly COSIM_CAT_CLEANUP_FAIL="cleanup_fail"
+readonly COSIM_CAT_INFRA_UNKNOWN="infra_unknown"
+
+is_infra_failure() {
+    local category="$1"
+    case "$category" in
+        "$COSIM_CAT_TEST_PASS"|"$COSIM_CAT_TEST_FAIL"|"$COSIM_CAT_TEST_TIMEOUT"|"$COSIM_CAT_INTERRUPT")
+            return 1 ;;
+        *)
+            return 0 ;;
+    esac
+}
+
+# ---- Resource Manifest ----
+
+COSIM_MANIFEST_FILE=""
+
+manifest_init() {
+    local session_dir="$1"
+    COSIM_MANIFEST_FILE="${session_dir}/resources.manifest"
+    mkdir -p "$session_dir"
+    : > "$COSIM_MANIFEST_FILE"
+}
+
+manifest_add() {
+    local role="$1"   # runtime or artifact
+    local type="$2"   # container, socket, shmem, file, directory
+    local path="$3"
+    [[ -n "$COSIM_MANIFEST_FILE" ]] || return 1
+    echo "${role}|${type}|${path}" >> "$COSIM_MANIFEST_FILE"
+}
+
+manifest_runtime_paths() {
+    [[ -f "$COSIM_MANIFEST_FILE" ]] || return
+    grep '^runtime|' "$COSIM_MANIFEST_FILE" | cut -d'|' -f3
+}
+
+manifest_artifact_paths() {
+    [[ -f "$COSIM_MANIFEST_FILE" ]] || return
+    grep '^artifact|' "$COSIM_MANIFEST_FILE" | cut -d'|' -f3
+}
+
+# ---- Diagnostic Artifact Capture ----
+
+capture_artifacts() {
+    local artifact_dir="$1"
+    local container_name="$2"
+    local screen_log="${3:-}"
+    local run_id="${4:-unknown}"
+    local category="${5:-$COSIM_CAT_INFRA_UNKNOWN}"
+
+    mkdir -p "$artifact_dir"
+
+    echo "run_id=${run_id}" > "${artifact_dir}/metadata.txt"
+    echo "category=${category}" >> "${artifact_dir}/metadata.txt"
+    echo "timestamp=$(date -Iseconds)" >> "${artifact_dir}/metadata.txt"
+
+    docker logs "$container_name" > "${artifact_dir}/gem5.log" 2>&1 || true
+    docker inspect "$container_name" > "${artifact_dir}/docker-inspect.json" 2>&1 || true
+
+    if [[ -n "$screen_log" && -f "$screen_log" ]]; then
+        cp "$screen_log" "${artifact_dir}/qemu-console.log" 2>/dev/null || true
+    fi
+
+    ls -la /dev/shm/ > "${artifact_dir}/devshm-listing.txt" 2>&1 || true
+    ls -la /tmp/gem5-mi300x*.sock > "${artifact_dir}/socket-listing.txt" 2>&1 || true
+    ps aux | grep -E '(gem5|qemu)' | grep -v grep > "${artifact_dir}/process-snapshot.txt" 2>&1 || true
+    docker ps -a --filter "name=gem5-cosim" > "${artifact_dir}/docker-ps.txt" 2>&1 || true
+}
+
+# ---- Cleanup Utilities ----
+
+cleanup_from_manifest() {
+    local container_name="$1"
+
+    # Snapshot runtime paths before deleting session directory
+    local -a runtime_paths=()
+    local path
+    while IFS= read -r path; do
+        [[ -z "$path" ]] && continue
+        runtime_paths+=("$path")
+    done < <(manifest_runtime_paths)
+
+    # Store for verify_cleanup
+    _COSIM_RUNTIME_PATHS=("${runtime_paths[@]+"${runtime_paths[@]}"}")
+
+    docker rm -f "$container_name" >/dev/null 2>&1 || true
+
+    for path in "${runtime_paths[@]+"${runtime_paths[@]}"}"; do
+        if [[ -d "$path" ]]; then
+            rm -rf "$path" 2>/dev/null || true
+        else
+            rm -f "$path" 2>/dev/null || true
+        fi
+    done
+}
+
+verify_cleanup() {
+    local timeout_secs="${1:-10}"
+    local container_name="${2:-}"
+    local elapsed=0
+
+    local -a paths=("${_COSIM_RUNTIME_PATHS[@]+"${_COSIM_RUNTIME_PATHS[@]}"}")
+
+    while [[ $elapsed -lt $timeout_secs ]]; do
+        local remaining=0
+
+        if [[ -n "$container_name" ]]; then
+            if docker inspect "$container_name" >/dev/null 2>&1; then
+                remaining=$((remaining + 1))
+            fi
+        fi
+
+        for path in "${paths[@]+"${paths[@]}"}"; do
+            if [[ -e "$path" ]]; then
+                remaining=$((remaining + 1))
+            fi
+        done
+
+        if [[ $remaining -eq 0 ]]; then
+            return 0
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+    return 1
+}
+
+_COSIM_RUNTIME_PATHS=()
+
+# ---- Force-Clean (Dry-Run by Default) ----
+
+force_clean_orphans() {
+    local confirm="${1:-false}"
+    local found=0
+
+    local c
+    while IFS= read -r c; do
+        [[ -z "$c" ]] && continue
+        echo "  orphan container: $c"
+        found=1
+        if [[ "$confirm" == "true" ]]; then
+            docker rm -f "$c" >/dev/null 2>&1 || true
+        fi
+    done < <(docker ps -a --filter "name=gem5-cosim-" --format '{{.Names}}' 2>/dev/null)
+
+    local f
+    for f in /tmp/gem5-mi300x-*.sock; do
+        [[ -e "$f" ]] || continue
+        echo "  orphan socket: $f"
+        found=1
+        if [[ "$confirm" == "true" ]]; then
+            rm -f "$f" 2>/dev/null || true
+        fi
+    done
+
+    for f in /dev/shm/mi300x-vram /dev/shm/mi300x-vram-* /dev/shm/cosim-guest-ram /dev/shm/cosim-guest-ram-*; do
+        [[ -e "$f" ]] || continue
+        echo "  orphan shmem: $f"
+        found=1
+        if [[ "$confirm" == "true" ]]; then
+            rm -f "$f" 2>/dev/null || true
+        fi
+    done
+
+    # Legacy un-namespaced resources
+    for f in /tmp/gem5-mi300x.sock; do
+        [[ -e "$f" ]] || continue
+        echo "  orphan legacy socket: $f"
+        found=1
+        if [[ "$confirm" == "true" ]]; then
+            rm -f "$f" 2>/dev/null || true
+        fi
+    done
+    if docker ps -a --format '{{.Names}}' 2>/dev/null | grep -qx 'gem5-cosim'; then
+        echo "  orphan legacy container: gem5-cosim"
+        found=1
+        if [[ "$confirm" == "true" ]]; then
+            docker rm -f gem5-cosim >/dev/null 2>&1 || true
+        fi
+    fi
+
+    if [[ $found -eq 0 ]]; then
+        echo "  (no orphaned resources found)"
+    elif [[ "$confirm" != "true" ]]; then
+        echo "  (dry-run: use --force-clean --confirm to delete)"
+    fi
+
+    return 0
+}
+
+# ---- Health Check ----
+
+check_readiness() {
+    local socket_path="$1"
+    local vram_shmem="$2"
+    local guest_ram_shmem="$3"
+    local container_name="$4"
+    local expected_vram_bytes="${5:-17179869184}"
+    local expected_ram_bytes="${6:-8589934592}"
+
+    if [[ ! -S "$socket_path" ]]; then
+        echo "readiness check failed: socket $socket_path does not exist or is not a Unix socket"
+        return 1
+    fi
+
+    if [[ ! -f "$vram_shmem" ]]; then
+        echo "readiness check failed: VRAM shmem $vram_shmem does not exist"
+        return 1
+    fi
+    local vram_size
+    vram_size="$(stat -c%s "$vram_shmem" 2>/dev/null || echo 0)"
+    if [[ "$vram_size" -ne "$expected_vram_bytes" ]]; then
+        echo "readiness check failed: VRAM shmem size $vram_size != expected $expected_vram_bytes"
+        return 1
+    fi
+
+    if [[ ! -f "$guest_ram_shmem" ]]; then
+        echo "readiness check failed: guest RAM shmem $guest_ram_shmem does not exist"
+        return 1
+    fi
+    local ram_size
+    ram_size="$(stat -c%s "$guest_ram_shmem" 2>/dev/null || echo 0)"
+    if [[ "$ram_size" -ne "$expected_ram_bytes" ]]; then
+        echo "readiness check failed: guest RAM shmem size $ram_size != expected $expected_ram_bytes"
+        return 1
+    fi
+
+    if [[ "$(docker inspect -f '{{.State.Running}}' "$container_name" 2>/dev/null)" != "true" ]]; then
+        echo "readiness check failed: container $container_name is not running"
+        return 1
+    fi
+
+    return 0
+}
+
+# ---- Preflight Audit ----
+
+run_preflight_audit() {
+    echo "=== Preflight Resource Audit ==="
+    echo "Timestamp: $(date -Iseconds)"
+    echo ""
+
+    echo "--- Docker containers (gem5-cosim) ---"
+    docker ps -a --filter "name=gem5-cosim" 2>/dev/null || echo "(docker not available)"
+    echo ""
+
+    echo "--- /dev/shm (cosim-related) ---"
+    ls -la /dev/shm/mi300x-vram* /dev/shm/cosim-guest-ram* 2>/dev/null || echo "(none found)"
+    echo ""
+
+    echo "--- /tmp sockets (gem5-mi300x) ---"
+    ls -la /tmp/gem5-mi300x*.sock 2>/dev/null || echo "(none found)"
+    echo ""
+
+    echo "--- gem5 processes ---"
+    pgrep -a gem5 2>/dev/null || echo "(none found)"
+    echo ""
+
+    echo "=== End Preflight Audit ==="
+}

--- a/scripts/cosim_lib.sh
+++ b/scripts/cosim_lib.sh
@@ -8,7 +8,7 @@ generate_run_id() {
     local ts
     ts="$(date +%Y%m%d-%H%M%S)"
     local rand
-    rand="$(head -c4 /dev/urandom | xxd -p)"
+    rand="$(od -An -tx1 -N4 /dev/urandom | tr -d ' \n')"
     echo "${ts}-${rand}"
 }
 

--- a/scripts/cosim_preflight.sh
+++ b/scripts/cosim_preflight.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=cosim_lib.sh
+# shellcheck disable=SC1091
 source "${SCRIPT_DIR}/cosim_lib.sh"
 
 run_preflight_audit

--- a/scripts/cosim_preflight.sh
+++ b/scripts/cosim_preflight.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Standalone preflight audit script.
+# Lists cosim-related resources without modifying anything.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=cosim_lib.sh
+source "${SCRIPT_DIR}/cosim_lib.sh"
+
+run_preflight_audit

--- a/scripts/run_cosim_tests.sh
+++ b/scripts/run_cosim_tests.sh
@@ -10,7 +10,7 @@ TESTS_DIR="${COSIM_DIR}/tests"
 KERNELS_DIR="${TESTS_DIR}/kernels"
 LAUNCH_SCRIPT="${SCRIPT_DIR}/cosim_launch.sh"
 
-# shellcheck source=cosim_lib.sh
+# shellcheck disable=SC1091
 source "${SCRIPT_DIR}/cosim_lib.sh"
 
 SESSION_NAME="${SESSION_NAME:-qemu-cosim-tests}"
@@ -112,6 +112,7 @@ if [[ "$REPEAT_COUNT" -gt 0 && "$RUN_ALL" -eq 0 ]]; then
     REPEAT_INFRA_FAIL=0
     declare -a REPEAT_MATRIX=()
 
+    # shellcheck disable=SC2317
     repeat_partial_summary() {
         echo ""
         echo "============================================================"
@@ -130,7 +131,6 @@ if [[ "$REPEAT_COUNT" -gt 0 && "$RUN_ALL" -eq 0 ]]; then
     for ((i=1; i<=REPEAT_COUNT; i++)); do
         iter_run_id="$(generate_run_id)"
         sub_session="${SESSION_NAME}-repeat-${i}"
-        sub_log="/tmp/${sub_session}.log"
         iter_artifact_dir="$(cosim_artifact_dir "$COSIM_DIR" "$REPEAT_OPERATOR" "$iter_run_id")"
 
         step "Repeat iteration $i/$REPEAT_COUNT (run-ID: $iter_run_id)"
@@ -298,6 +298,7 @@ on_interrupt() {
     exit 130
 }
 
+# shellcheck disable=SC2317
 on_exit() {
     local rc=$?
     if [[ $rc -ne 0 && "$KEEP_ALIVE_ON_SUCCESS" -eq 0 ]]; then
@@ -427,10 +428,12 @@ else
     fi
     cname="$(cosim_container_name "$COSIM_RUN_ID")"
     docker logs "$cname" > "${runner_artifact_dir}/gem5.log" 2>&1 || true
-    echo "run_id=${COSIM_RUN_ID}" > "${runner_artifact_dir}/metadata.txt"
-    echo "category=${COSIM_CAT_TEST_FAIL}" >> "${runner_artifact_dir}/metadata.txt"
-    echo "test=${TEST_NAME}" >> "${runner_artifact_dir}/metadata.txt"
-    echo "exit_code=${result_rc}" >> "${runner_artifact_dir}/metadata.txt"
+    {
+        echo "run_id=${COSIM_RUN_ID}"
+        echo "category=${COSIM_CAT_TEST_FAIL}"
+        echo "test=${TEST_NAME}"
+        echo "exit_code=${result_rc}"
+    } > "${runner_artifact_dir}/metadata.txt"
 fi
 
 if [[ "$KEEP_ALIVE_ON_SUCCESS" -eq 1 && "$result_rc" -eq 0 ]]; then

--- a/scripts/run_cosim_tests.sh
+++ b/scripts/run_cosim_tests.sh
@@ -10,12 +10,16 @@ TESTS_DIR="${COSIM_DIR}/tests"
 KERNELS_DIR="${TESTS_DIR}/kernels"
 LAUNCH_SCRIPT="${SCRIPT_DIR}/cosim_launch.sh"
 
+# shellcheck source=cosim_lib.sh
+source "${SCRIPT_DIR}/cosim_lib.sh"
+
 SESSION_NAME="${SESSION_NAME:-qemu-cosim-tests}"
 SCREEN_LOG="${SCREEN_LOG:-}"
 BOOT_TIMEOUT_SECS="${BOOT_TIMEOUT_SECS:-240}"
 TEST_TIMEOUT_SECS="${TEST_TIMEOUT_SECS:-60}"
 KEEP_ALIVE_ON_SUCCESS=0
 RUN_ALL=0
+REPEAT_COUNT=0
 FILTER=""
 PASSTHROUGH_ARGS=()
 SCREEN_LOG_SET=0
@@ -44,6 +48,7 @@ Usage: $0 [options] <operator-filter>
 
 Options:
   --all                  Run all operators, one fresh cosim session each
+  --repeat N             Run the same operator N times (fresh session each)
   --keep-alive           Leave QEMU + gem5 running after a successful test
   --session-name NAME    detached session name (default: qemu-cosim-tests)
   --screen-log PATH      console log path (default: /tmp/qemu-cosim-tests.log)
@@ -59,6 +64,7 @@ EOF
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --all)              RUN_ALL=1; shift ;;
+        --repeat)           REPEAT_COUNT="$2"; shift 2 ;;
         --keep-alive)       KEEP_ALIVE_ON_SUCCESS=1; shift ;;
         --session-name)     SESSION_NAME="$2"; shift 2 ;;
         --screen-log)       SCREEN_LOG="$2"; SCREEN_LOG_SET=1; shift 2 ;;
@@ -70,11 +76,120 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if [[ "$SCREEN_LOG_SET" -eq 0 ]]; then
-    SCREEN_LOG="/tmp/${SESSION_NAME}.log"
+COSIM_RUN_ID="${COSIM_RUN_ID:-$(generate_run_id)}"
+export COSIM_RUN_ID
+
+if [[ "$REPEAT_COUNT" -gt 0 && "$KEEP_ALIVE_ON_SUCCESS" -eq 1 ]]; then
+    error "--keep-alive and --repeat cannot be used together"
 fi
-SESSION_DIR="/tmp/${SESSION_NAME}.session"
+if [[ "$REPEAT_COUNT" -gt 0 && "$RUN_ALL" -eq 1 ]]; then
+    error "--all and --repeat cannot be used together"
+fi
+
+if [[ "$SCREEN_LOG_SET" -eq 0 ]]; then
+    SCREEN_LOG="$(cosim_screen_log "$COSIM_RUN_ID" "$SESSION_NAME")"
+fi
+SESSION_DIR="$(cosim_session_dir "$COSIM_RUN_ID" "$SESSION_NAME")"
 SESSION_FIFO="${SESSION_DIR}/console.in"
+
+# ---- Repeat mode: run same operator N times with fresh sessions ----
+
+if [[ "$REPEAT_COUNT" -gt 0 && "$RUN_ALL" -eq 0 ]]; then
+    [[ -n "$FILTER" ]] || { echo "Usage: $0 --repeat N <operator>"; exit 1; }
+
+    # Resolve exact operator name for artifact paths
+    REPEAT_OPERATOR=""
+    while IFS= read -r k; do
+        k="${k%.cpp}"
+        if [[ "$k" == *"$FILTER"* ]]; then
+            REPEAT_OPERATOR="$k"
+        fi
+    done < <(find "$KERNELS_DIR" -maxdepth 1 -type f -name '*.cpp' -printf '%f\n' | sort)
+    REPEAT_OPERATOR="${REPEAT_OPERATOR:-$FILTER}"
+
+    REPEAT_PASSED=0
+    REPEAT_FAILED=0
+    REPEAT_INFRA_FAIL=0
+    declare -a REPEAT_MATRIX=()
+
+    repeat_partial_summary() {
+        echo ""
+        echo "============================================================"
+        echo "  Repeat-Run Partial Summary (interrupted)"
+        echo "  Operator: $FILTER"
+        echo "  Completed: $((REPEAT_PASSED + REPEAT_FAILED)) / $REPEAT_COUNT"
+        echo "  Passed: $REPEAT_PASSED  Failed: $REPEAT_FAILED  Infra failures: $REPEAT_INFRA_FAIL"
+        echo "============================================================"
+        for entry in "${REPEAT_MATRIX[@]}"; do
+            echo "  $entry"
+        done
+        echo "============================================================"
+    }
+    trap 'repeat_partial_summary; exit 130' INT TERM
+
+    for ((i=1; i<=REPEAT_COUNT; i++)); do
+        iter_run_id="$(generate_run_id)"
+        sub_session="${SESSION_NAME}-repeat-${i}"
+        sub_log="/tmp/${sub_session}.log"
+        iter_artifact_dir="$(cosim_artifact_dir "$COSIM_DIR" "$REPEAT_OPERATOR" "$iter_run_id")"
+
+        step "Repeat iteration $i/$REPEAT_COUNT (run-ID: $iter_run_id)"
+
+        iter_category_file="/tmp/cosim-category-${iter_run_id}"
+        if COSIM_RUN_ID="$iter_run_id" COSIM_CATEGORY_FILE="$iter_category_file" "$0" \
+            --session-name "$sub_session" \
+            --boot-timeout "$BOOT_TIMEOUT_SECS" \
+            --test-timeout "$TEST_TIMEOUT_SECS" \
+            "${PASSTHROUGH_ARGS[@]}" \
+            "$FILTER"; then
+            run_rc=0
+            category="$COSIM_CAT_TEST_PASS"
+        else
+            run_rc=$?
+            category="$COSIM_CAT_INFRA_UNKNOWN"
+        fi
+        if [[ -f "$iter_category_file" ]]; then
+            category="$(cat "$iter_category_file")"
+            rm -f "$iter_category_file"
+        fi
+
+        if [[ "$run_rc" -eq 0 ]]; then
+            REPEAT_PASSED=$((REPEAT_PASSED + 1))
+        else
+            REPEAT_FAILED=$((REPEAT_FAILED + 1))
+            if is_infra_failure "$category"; then
+                REPEAT_INFRA_FAIL=$((REPEAT_INFRA_FAIL + 1))
+            fi
+        fi
+        if [[ -d "$iter_artifact_dir" ]]; then
+            actual_artifact_dir="$iter_artifact_dir"
+        elif [[ -d "${COSIM_DIR}/artifacts/standalone/${iter_run_id}" ]]; then
+            actual_artifact_dir="${COSIM_DIR}/artifacts/standalone/${iter_run_id}"
+        else
+            actual_artifact_dir="(none)"
+        fi
+        REPEAT_MATRIX+=("$i | $iter_run_id | $category | exit=$run_rc | artifacts=${actual_artifact_dir}")
+    done
+
+    echo ""
+    echo "============================================================"
+    echo "  Repeat-Run Results"
+    echo "  Operator: $FILTER"
+    echo "  Total: $REPEAT_COUNT  Passed: $REPEAT_PASSED  Failed: $REPEAT_FAILED  Infra failures: $REPEAT_INFRA_FAIL"
+    echo "============================================================"
+    echo "  # | Run-ID | Category | Exit | Artifacts"
+    echo "  --|--------|----------|------|----------"
+    for entry in "${REPEAT_MATRIX[@]}"; do
+        echo "  $entry"
+    done
+    echo "============================================================"
+
+    if [[ "$REPEAT_INFRA_FAIL" -gt 0 ]]; then
+        exit 1
+    fi
+    [[ "$REPEAT_FAILED" -eq 0 ]]
+    exit $?
+fi
 
 if [[ "$RUN_ALL" -eq 1 ]]; then
     mapfile -t ALL_TESTS < <(find "$KERNELS_DIR" -maxdepth 1 -type f -name '*.cpp' -printf '%f\n' | sed 's/\.cpp$//' | sort)
@@ -85,10 +200,8 @@ if [[ "$RUN_ALL" -eq 1 ]]; then
 
     for test_name in "${ALL_TESTS[@]}"; do
         sub_session="${SESSION_NAME}-${test_name}"
-        sub_log="/tmp/${sub_session}.log"
-        if "$0" \
+        if COSIM_RUN_ID="$(generate_run_id)" "$0" \
             --session-name "$sub_session" \
-            --screen-log "$sub_log" \
             --boot-timeout "$BOOT_TIMEOUT_SECS" \
             --test-timeout "$TEST_TIMEOUT_SECS" \
             "${PASSTHROUGH_ARGS[@]}" \
@@ -117,16 +230,29 @@ fi
 [[ -n "$FILTER" ]] || usage
 
 cleanup_session() {
-    if [[ -n "${LAUNCH_PID:-}" ]]; then
+    if [[ -n "${LAUNCH_PID:-}" ]] && kill -0 "$LAUNCH_PID" 2>/dev/null; then
         kill -TERM -- "-${LAUNCH_PID}" >/dev/null 2>&1 || true
-        sleep 1
-        kill -KILL -- "-${LAUNCH_PID}" >/dev/null 2>&1 || true
+        local wait_count=0
+        while kill -0 "$LAUNCH_PID" 2>/dev/null && [[ $wait_count -lt 15 ]]; do
+            sleep 1
+            wait_count=$((wait_count + 1))
+        done
+        if kill -0 "$LAUNCH_PID" 2>/dev/null; then
+            kill -KILL -- "-${LAUNCH_PID}" >/dev/null 2>&1 || true
+        fi
     fi
-    docker rm -f gem5-cosim >/dev/null 2>&1 || true
+    local cname
+    cname="$(cosim_container_name "${COSIM_RUN_ID:-}")"
+    docker rm -f "$cname" >/dev/null 2>&1 || true
     rm -rf "$SESSION_DIR" >/dev/null 2>&1 || true
-    # Clean up single-GPU and multi-GPU socket/shmem paths
-    rm -f /tmp/gem5-mi300x.sock /dev/shm/mi300x-vram /dev/shm/cosim-guest-ram 2>/dev/null || true
-    rm -f /tmp/gem5-mi300x-[0-9]*.sock /dev/shm/mi300x-vram-[0-9]* 2>/dev/null || true
+    rm -f "/tmp/cosim-launcher-category-${COSIM_RUN_ID:-}.txt" "/tmp/cosim-test-done-${COSIM_RUN_ID:-}" 2>/dev/null || true
+    if [[ -n "${COSIM_RUN_ID:-}" ]]; then
+        rm -f "/tmp/gem5-mi300x-${COSIM_RUN_ID}.sock" 2>/dev/null || true
+        rm -f "/tmp/gem5-mi300x-${COSIM_RUN_ID}-"[0-9]*.sock 2>/dev/null || true
+        rm -f "/dev/shm/mi300x-vram-${COSIM_RUN_ID}" 2>/dev/null || true
+        rm -f "/dev/shm/mi300x-vram-${COSIM_RUN_ID}-"[0-9]* 2>/dev/null || true
+        rm -f "/dev/shm/cosim-guest-ram-${COSIM_RUN_ID}" 2>/dev/null || true
+    fi
 }
 
 session_alive() {
@@ -138,18 +264,49 @@ send_guest() {
     printf '%s\n' "$line" >&$CONTROL_FD
 }
 
+record_category() {
+    local cat="$1"
+    local use_launcher="${2:-false}"
+    if [[ "$use_launcher" == "true" ]]; then
+        local launcher_cat_file="/tmp/cosim-launcher-category-${COSIM_RUN_ID}.txt"
+        if [[ -f "$launcher_cat_file" ]]; then
+            local launcher_cat
+            launcher_cat="$(cat "$launcher_cat_file")"
+            rm -f "$launcher_cat_file"
+            if [[ -n "$launcher_cat" && "$launcher_cat" != "$COSIM_CAT_TEST_PASS" ]]; then
+                cat="$launcher_cat"
+            fi
+        fi
+    fi
+    if [[ -n "${COSIM_CATEGORY_FILE:-}" ]]; then
+        echo "$cat" > "$COSIM_CATEGORY_FILE"
+    fi
+}
+
 # shellcheck disable=SC2317,SC2329
 on_interrupt() {
     echo ""
-    warn "Interrupted. The current QEMU + gem5 session remains running."
-    warn "Launcher PID: ${LAUNCH_PID:-unknown}"
-    warn "Console log: ${SCREEN_LOG}"
-    warn "Console pipe: ${SESSION_FIFO}"
-    warn "Cleanup: kill -TERM -- -${LAUNCH_PID:-0}; docker rm -f gem5-cosim"
+    if [[ "$KEEP_ALIVE_ON_SUCCESS" -eq 1 ]]; then
+        warn "Interrupted. Session preserved (--keep-alive)."
+        warn "Launcher PID: ${LAUNCH_PID:-unknown}"
+        warn "Console log: ${SCREEN_LOG}"
+        warn "Cleanup: kill -TERM -- -${LAUNCH_PID:-0}; docker rm -f $(cosim_container_name "${COSIM_RUN_ID:-}")"
+    else
+        warn "Interrupted. Cleaning up session..."
+        cleanup_session
+    fi
     exit 130
 }
 
+on_exit() {
+    local rc=$?
+    if [[ $rc -ne 0 && "$KEEP_ALIVE_ON_SUCCESS" -eq 0 ]]; then
+        cleanup_session
+    fi
+}
+
 trap on_interrupt INT TERM
+trap on_exit EXIT
 
 match_test() {
     local matches=()
@@ -174,7 +331,7 @@ match_test() {
 }
 
 TEST_NAME="$(match_test)"
-GUEST_SCRIPT=".cosim_guest_run.${SESSION_NAME}.${TEST_NAME}.sh"
+GUEST_SCRIPT=".cosim_guest_run.${COSIM_RUN_ID}.${TEST_NAME}.sh"
 GUEST_SCRIPT_HOST="${TESTS_DIR}/${GUEST_SCRIPT}"
 TOKEN="COSIM_TEST_DONE_${TEST_NAME}_$(date +%s)"
 
@@ -199,10 +356,12 @@ while true; do
     fi
     if ! session_alive; then
         rm -f "$GUEST_SCRIPT_HOST"
+        record_category "$COSIM_CAT_QEMU_EXIT" "true"
         error "[${TEST_NAME}] detached session exited during boot. Log tail:\n$(tail -n 40 "$SCREEN_LOG" 2>/dev/null)"
     fi
     now_ts=$(date +%s)
     if (( now_ts - start_ts >= BOOT_TIMEOUT_SECS )); then
+        record_category "$COSIM_CAT_BOOT_TIMEOUT" "true"
         error "[${TEST_NAME}] guest did not reach login prompt within ${BOOT_TIMEOUT_SECS}s"
     fi
     sleep 2
@@ -249,6 +408,7 @@ while true; do
     fi
     if ! session_alive; then
         rm -f "$GUEST_SCRIPT_HOST"
+        record_category "$COSIM_CAT_QEMU_EXIT" "true"
         error "[${TEST_NAME}] detached session exited before the test finished. Log tail:\n$(tail -n 80 "$SCREEN_LOG" 2>/dev/null)"
     fi
     sleep 1
@@ -256,11 +416,30 @@ done
 
 rm -f "$GUEST_SCRIPT_HOST"
 
+if [[ "$result_rc" -eq 0 ]]; then
+    record_category "$COSIM_CAT_TEST_PASS"
+else
+    record_category "$COSIM_CAT_TEST_FAIL"
+    runner_artifact_dir="$(cosim_artifact_dir "$COSIM_DIR" "${TEST_NAME}" "$COSIM_RUN_ID")"
+    mkdir -p "$runner_artifact_dir"
+    if [[ -f "$SCREEN_LOG" ]]; then
+        cp "$SCREEN_LOG" "${runner_artifact_dir}/qemu-console.log" 2>/dev/null || true
+    fi
+    cname="$(cosim_container_name "$COSIM_RUN_ID")"
+    docker logs "$cname" > "${runner_artifact_dir}/gem5.log" 2>&1 || true
+    echo "run_id=${COSIM_RUN_ID}" > "${runner_artifact_dir}/metadata.txt"
+    echo "category=${COSIM_CAT_TEST_FAIL}" >> "${runner_artifact_dir}/metadata.txt"
+    echo "test=${TEST_NAME}" >> "${runner_artifact_dir}/metadata.txt"
+    echo "exit_code=${result_rc}" >> "${runner_artifact_dir}/metadata.txt"
+fi
+
 if [[ "$KEEP_ALIVE_ON_SUCCESS" -eq 1 && "$result_rc" -eq 0 ]]; then
     info "[${TEST_NAME}] Leaving QEMU + gem5 running (--keep-alive)"
     info "Console log: ${SCREEN_LOG}"
     info "Console pipe: ${SESSION_FIFO}"
 else
+    # Signal launcher that test completed normally — skip artifact capture on TERM
+    touch "/tmp/cosim-test-done-${COSIM_RUN_ID}" 2>/dev/null || true
     step "[${TEST_NAME}] Cleaning up detached session..."
     cleanup_session
 fi

--- a/scripts/run_cosim_tests.sh
+++ b/scripts/run_cosim_tests.sh
@@ -441,8 +441,9 @@ if [[ "$KEEP_ALIVE_ON_SUCCESS" -eq 1 && "$result_rc" -eq 0 ]]; then
     info "Console log: ${SCREEN_LOG}"
     info "Console pipe: ${SESSION_FIFO}"
 else
-    # Signal launcher that test completed normally — skip artifact capture on TERM
-    touch "/tmp/cosim-test-done-${COSIM_RUN_ID}" 2>/dev/null || true
+    if [[ "$result_rc" -eq 0 ]]; then
+        touch "/tmp/cosim-test-done-${COSIM_RUN_ID}" 2>/dev/null || true
+    fi
     step "[${TEST_NAME}] Cleaning up detached session..."
     cleanup_session
 fi


### PR DESCRIPTION
## Summary

- Introduce `COSIM_RUN_ID` namespace to isolate all per-session resources (container, socket, VRAM shmem, guest-RAM shmem)
- Add `scripts/cosim_lib.sh` shared library: 12-category failure taxonomy, resource manifest (runtime/artifact), manifest-driven cleanup, post-teardown verification (10s timeout), pre-launch health check, preflight audit, diagnostic artifact capture
- Rewrite `cosim_launch.sh` cleanup handler: classify failure → capture artifacts → cleanup → verify
- Add `--repeat N` flag to `run_cosim_tests.sh`: fresh session per iteration, pass/fail matrix with failure category
- Add `--force-clean` dry-run mode for orphan resource management

## Test plan

- [ ] `bash -n scripts/cosim_lib.sh scripts/cosim_launch.sh scripts/run_cosim_tests.sh scripts/cosim_preflight.sh` syntax check passes
- [ ] `./scripts/cosim_launch.sh --force-clean` lists orphaned resources (dry-run)
- [ ] `./scripts/cosim_launch.sh` starts normally with Run-ID shown in banner
- [ ] `./scripts/run_cosim_tests.sh --repeat 20 vector_add` passes 20 consecutive sessions with zero infrastructure failures
- [ ] `./scripts/run_cosim_tests.sh --keep-alive --repeat 3 vector_add` rejects the combination and exits with error
- [ ] On failure, `artifacts/` directory contains gem5 logs, QEMU console log, and process snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)