### PR TITLE
chore: vendor cosim-gpu-skills into .agents directory

### DIFF
--- a/.agents/.codex-plugin/plugin.json
+++ b/.agents/.codex-plugin/plugin.json
@@ -1,0 +1,33 @@
+{
+  "name": "cosim-gpu-skills",
+  "version": "0.1.0",
+  "description": "Reusable Codex skills for cosim-gpu QEMU and gem5 workflows.",
+  "author": {
+    "name": "Chao Liu",
+    "email": "chao.liu@processmission.com",
+    "url": "https://github.com/zevorn"
+  },
+  "repository": "https://github.com/gevico/cosim-gpu-skills",
+  "license": "Apache-2.0",
+  "keywords": [
+    "cosim-gpu",
+    "qemu",
+    "gem5",
+    "mi300x",
+    "skills"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "cosim-gpu skills",
+    "shortDescription": "QEMU+gem5 MI300X co-simulation workflows.",
+    "longDescription": "Reusable skills for debugging, guest interaction, and guest disk-image maintenance in the cosim-gpu project.",
+    "developerName": "Chao Liu",
+    "category": "Productivity",
+    "capabilities": [
+      "Code",
+      "Debug",
+      "Operations"
+    ],
+    "defaultPrompt": "Use the cosim-gpu skills to diagnose and verify a QEMU+gem5 MI300X co-simulation issue."
+  }
+}

--- a/.agents/.gitignore
+++ b/.agents/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/.agents/LICENSE
+++ b/.agents/LICENSE
@@ -1,0 +1,200 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. Please also get an OpenPGP
+      key ID from a public key server, and include it in the notice.
+
+   Copyright 2026 Chao Liu
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.agents/skills/cosim-gpu-build/SKILL.md
+++ b/.agents/skills/cosim-gpu-build/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: cosim-gpu-build
+description: Use when building gem5 or QEMU, checking build provenance, or preserving gem5 incremental builds across worktrees. Delegates to scripts/cosim_build.sh; never hand-roll Docker, scons, or QEMU make commands.
+---
+
+# Cosim Build
+
+Build gem5 and QEMU for cosim through `scripts/cosim_build.sh`. This script is
+the single source of truth for compilation, metadata, and incremental skip
+behavior.
+
+## Quickstart
+
+```bash
+bash scripts/cosim_build.sh gem5
+bash scripts/cosim_build.sh qemu
+bash scripts/cosim_build.sh all
+bash scripts/cosim_build.sh gem5 --force
+```
+
+For an isolated gem5 worktree:
+
+```bash
+GEM5_DIR=/abs/path/to/gem5-worktree bash scripts/cosim_build.sh gem5
+```
+
+When testing that worktree, pass the matching binary explicitly:
+
+```bash
+--gem5-bin /abs/path/to/gem5-worktree/build/VEGA_X86/gem5.opt
+```
+
+## Required Policy
+
+Read `references/build-policy-and-provenance.md` before deciding whether to
+rebuild, accepting binary evidence, using a nonstandard binary, or responding
+to stale metadata.
+
+Read `references/worktree-incremental-build.md` before creating an isolated
+worktree, copying build outputs, removing an artifact worktree, or accepting
+evidence from a nonstandard gem5 worktree.
+
+Do not run raw `docker run ... scons`, direct `scons`, or `make -C qemu/build`
+commands as substitutes for the build script.
+
+## Binary Locations
+
+| Component | Binary |
+|-----------|--------|
+| gem5 | `gem5/build/VEGA_X86/gem5.opt` |
+| QEMU | `qemu/build/qemu-system-x86_64` |
+
+The build script creates the Docker image from `scripts/Dockerfile.run` when it
+is missing.
+
+## Integration
+
+- `cosim-gpu-flow-plan` records source bases before build evidence matters.
+- `cosim-gpu-test` and `cosim-gpu-debug` check provenance before launch.
+- After any rebuild, all earlier test evidence is stale for current source
+  until rerun with the intended binary.
+
+## Verification
+
+```bash
+bash scripts/cosim_build.sh gem5
+cat gem5/build/VEGA_X86/.cosim-build-meta
+bash scripts/cosim_build.sh gem5
+```
+
+The second run should report that gem5 is up to date and skip rebuilding.

--- a/.agents/skills/cosim-gpu-build/references/build-policy-and-provenance.md
+++ b/.agents/skills/cosim-gpu-build/references/build-policy-and-provenance.md
@@ -1,0 +1,96 @@
+# Build Policy And Provenance
+
+Read this when deciding whether to build, accepting binary evidence, using a
+nonstandard binary, or evaluating stale provenance.
+
+## Autonomy Rule
+
+Run the standard metadata inspection and incremental build path directly.
+`bash scripts/cosim_build.sh gem5`, `qemu`, or `all` is the authorized build
+interface whenever a task needs a current binary or provenance reports stale
+metadata.
+
+Missing metadata, stale metadata, missing binary, or source edits since the
+last accepted test are execution conditions, not user decision points.
+
+Do not pause before standard incremental builds, build metadata reads, binary
+hash reads, or local Docker image creation performed by
+`scripts/cosim_build.sh`. If the execution platform requires authorization,
+request only the narrow build-script prefix.
+
+Ask only before a full or cold rebuild, deleting build directories, creating a
+fresh worktree only for rebuild, changing the standard binary path, or using
+`--force` when stale metadata does not require it.
+
+## Default Decision Rule
+
+Inspect existing binary and metadata before rebuilding:
+
+```bash
+git -C gem5 rev-parse HEAD
+git -C gem5 log -1 --format='%H%n%s%n%b'
+cat gem5/build/VEGA_X86/.cosim-build-meta
+sha256sum gem5/build/VEGA_X86/gem5.opt
+```
+
+Run `bash scripts/cosim_build.sh gem5` when the binary is missing, metadata is
+missing, recorded commit or source fingerprint differs from current source, or
+a source edit invalidated prior rows. This remains the standard incremental
+path.
+
+Use `--force` only for an explicit user request to prove the build pipeline or
+for explicit end-to-end build confirmation.
+
+Full clean rebuilds, such as deleting `build/VEGA_X86`, are almost never
+appropriate during debugging. A suspected cache issue is not enough by itself;
+record the suspicion and use provenance checks plus incremental rebuilds unless
+the user explicitly requested a full rebuild.
+
+Do not create a new worktree or cold-build gem5 just to prove which binary a
+test used. Pass the intended binary path explicitly and record metadata plus
+hash in the active artifact workspace.
+
+## Rebuild Metadata
+
+For gem5, `scripts/cosim_build.sh` writes
+`gem5/build/VEGA_X86/.cosim-build-meta`:
+
+```text
+commit=<sha>
+source_fingerprint=<sha256>
+timestamp=<iso8601>
+target=VEGA_X86
+```
+
+If current commit and source fingerprint match metadata, the build is skipped.
+If rebuild is needed, rely on the script's incremental behavior.
+
+For QEMU, metadata lives in `qemu/build/.cosim-build-meta`. Rebuild
+incrementally only when binary or metadata is missing, metadata mismatches,
+source changed, or QEMU build behavior itself is under test.
+
+## Source And Binary Provenance
+
+For PR, review, RLCR, or bug-localization tasks, treat
+`gem5/build/VEGA_X86/gem5.opt` as the only valid gem5 test binary unless the
+plan explicitly names another binary.
+
+Before accepting a test row as evidence, record:
+
+```bash
+git -C gem5 rev-parse HEAD
+git -C gem5 log -1 --format='%H%n%s%n%b'
+cat gem5/build/VEGA_X86/.cosim-build-meta
+stat -c '%n %s %y' gem5/build/VEGA_X86/gem5.opt
+sha256sum gem5/build/VEGA_X86/gem5.opt
+```
+
+If a launch log shows `<repo-root>/build/VEGA_X86/gem5.opt` or
+container path `/gem5-bin/gem5.opt`, classify that row as an alternate-binary
+sample. It must not prove a current gem5 PR unless the plan targeted that
+binary.
+
+For a planned isolated worktree, the accepted binary is the explicitly named
+`<worktree>/build/VEGA_X86/gem5.opt`. Record `GEM5_DIR`, worktree `HEAD`, build
+commit message, build metadata, binary stat, and binary hash from that same
+worktree before accepting test evidence.

--- a/.agents/skills/cosim-gpu-build/references/worktree-incremental-build.md
+++ b/.agents/skills/cosim-gpu-build/references/worktree-incremental-build.md
@@ -1,0 +1,104 @@
+# Worktree Incremental Build Reuse
+
+Use this reference when a task needs isolated gem5 source edits while preserving
+incremental build behavior. Typical triggers are concurrent Codex conversations,
+parallel debug experiments, or a user request to explicitly specify a gem5
+worktree.
+
+## Contract
+
+- Keep `scripts/cosim_build.sh` as the only build interface.
+- Use `GEM5_DIR` to select the intended gem5 worktree.
+- Use `--gem5-bin` to select the matching `gem5.opt` for tests or launchers.
+- Treat copied build output as a warm starting point, not proof that no rebuild
+  is needed.
+- Do not classify rows from a worktree as valid evidence unless provenance was
+  recorded from that same worktree.
+
+## Procedure
+
+1. Record the source worktree state:
+
+```bash
+git -C gem5 rev-parse HEAD
+git -C gem5 log -1 --format='%H%n%s%n%b'
+cat gem5/build/VEGA_X86/.cosim-build-meta
+stat -c '%n %s %y' gem5/build/VEGA_X86/gem5.opt
+sha256sum gem5/build/VEGA_X86/gem5.opt
+```
+
+2. Create an isolated worktree under the active artifact workspace. Prefer a
+   detached worktree when the user does not request a branch:
+
+```bash
+git -C gem5 worktree add --detach /abs/path/to/artifacts/<task>/worktrees/gem5-debug <commit>
+```
+
+3. Copy the existing build directory into the new worktree. Prefer reflinks
+   because the build directory may be large:
+
+```bash
+cp -a --reflink=auto gem5/build /abs/path/to/artifacts/<task>/worktrees/gem5-debug/build
+```
+
+4. Refresh the copied build output through the standard script:
+
+```bash
+GEM5_DIR=/abs/path/to/artifacts/<task>/worktrees/gem5-debug bash scripts/cosim_build.sh gem5
+```
+
+5. Verify the new worktree has its own build metadata:
+
+```bash
+git -C /abs/path/to/artifacts/<task>/worktrees/gem5-debug rev-parse HEAD
+git -C /abs/path/to/artifacts/<task>/worktrees/gem5-debug log -1 --format='%H%n%s%n%b'
+cat /abs/path/to/artifacts/<task>/worktrees/gem5-debug/build/VEGA_X86/.cosim-build-meta
+stat -c '%n %s %y' /abs/path/to/artifacts/<task>/worktrees/gem5-debug/build/VEGA_X86/gem5.opt
+sha256sum /abs/path/to/artifacts/<task>/worktrees/gem5-debug/build/VEGA_X86/gem5.opt
+```
+
+6. Run a second build check when time permits. A skip message proves the copied
+   directory has become an independent incremental baseline for that worktree:
+
+```bash
+GEM5_DIR=/abs/path/to/artifacts/<task>/worktrees/gem5-debug bash scripts/cosim_build.sh gem5
+```
+
+Expected skip text:
+
+```text
+gem5 up to date (commit <sha>), skipping build
+```
+
+7. Launch tests with the matching binary path:
+
+```bash
+--gem5-bin /abs/path/to/artifacts/<task>/worktrees/gem5-debug/build/VEGA_X86/gem5.opt
+```
+
+## Interpretation
+
+The copied build directory may still rebuild generated files, object files, or
+`gem5.opt` on the first pass. This is expected because the build system can
+store absolute paths, command signatures, dependency scans, and source
+fingerprints. The important distinction is whether the first pass is smaller
+than a cold build and whether the second pass skips or performs only local
+incremental work.
+
+If the standard `gem5` worktree changes while the isolated worktree remains at
+its intended commit, treat that as evidence that the isolation is working. It
+does not by itself prove any test result; test evidence still depends on the
+explicit `--gem5-bin` path and matching metadata.
+
+## Evidence to record
+
+- Worktree path and creation command.
+- Source commit hash and commit message used for the worktree.
+- Source worktree commit hash and commit message when copied build output came
+  from another path.
+- Whether `gem5/build` was copied with `--reflink=auto`.
+- First build log path and elapsed time.
+- Second build log path and skip or rebuild outcome.
+- Worktree `build/VEGA_X86/.cosim-build-meta`.
+- `stat` and `sha256sum` for the worktree `gem5.opt`.
+- Exact `--gem5-bin` value used by every accepted test row.

--- a/.agents/skills/cosim-gpu-codex-review/SKILL.md
+++ b/.agents/skills/cosim-gpu-codex-review/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: cosim-gpu-codex-review
+description: Use when delegating independent code review, design review, or focused bug investigation to an AI reviewer. Provides delegation templates and records reviewer evidence; higher-level review flow remains in cosim-gpu-review or cosim-gpu-rlcr-loop.
+---
+
+# Codex Review
+
+Use an independent AI reviewer for bounded technical review, investigation, or
+design critique. This skill owns delegation mechanics only. Review policy shared
+with `cosim-gpu-review` and `cosim-gpu-rlcr-loop` lives in
+`../cosim-gpu-review/references/review/independent-review-contract.md`; read it
+before adversarial review delegation.
+
+## Scope
+
+Use this skill for:
+
+- adversarial code review from a written brief
+- single-file or subsystem investigation with explicit questions
+- design critique of a proposed local change
+- second opinion when the main investigation is stuck
+
+Do not delegate user interaction, task scoping, build commands, test commands,
+or final verification. The main agent owns integration and evidence acceptance.
+
+## Assignment Template
+
+Each assignment must be self-contained:
+
+```markdown
+# Target
+Exact files, symbols, base reference, current HEAD, and non-goals.
+
+# Change Or Review Question
+For review: dimensions to inspect and exact diff commands.
+For investigation: symptom, search scope, and questions.
+For design: current code, constraints, and rejected directions if artifact-backed.
+
+# Acceptance
+Expected output format, severity labels, and required evidence.
+No project-wide build, test, or lint commands.
+```
+
+Implementation-oriented assignments must require current `HEAD` as the edit
+base, diff-scoped formatting only, and no whole-file formatter churn unless the
+task is explicitly formatting-only.
+
+## Adversarial Review Prompt
+
+Prepare the review brief through `cosim-gpu-review` or `cosim-gpu-rlcr-loop`.
+The sub-agent prompt points to that brief and may include exact scoped diff
+commands. It must not include the implementer's theory, desired result, or
+dialogue summary.
+
+For cosim-specific prompts, use
+`references/cosim-gpu-review-prompts.md` when the touched subsystem matches
+interrupt handling, PM4, cache or TLB behavior, HSA completion signals, or
+similar GPU model paths.
+
+## Evidence Recording
+
+Save every consultation under the active task workspace:
+
+```text
+artifacts/<task-slug>/reviews/codex-<round>-<file>.md
+artifacts/<task-slug>/reviews/codex-<round>-summary.md
+```
+
+Record prompt, file scope, response, classification, and disposition. If the
+reviewer times out or errors, retry once with a narrower scope and record the
+failure if it still fails.
+
+## Provider Notes
+
+Default to Codex for local code review and Gemini for research that needs
+current external documentation. If the provider is unavailable and setup cost
+exceeds review value, fall back to manual review and record that choice.
+
+Proxy and sandbox issues are operational details, not review findings. When a
+sub-agent creates stray files, verify with repository status and remove only
+files proven to be sub-agent artifacts.

--- a/.agents/skills/cosim-gpu-codex-review/references/cosim-gpu-review-prompts.md
+++ b/.agents/skills/cosim-gpu-codex-review/references/cosim-gpu-review-prompts.md
@@ -1,0 +1,50 @@
+# Cosim-Specific Codex Review Prompts
+
+Subsystem-specific adversarial review prompts for cosim. Use these when delegating
+code review to Codex; keep the generic prompt templates in the main skill.
+
+## Interrupt handler
+```
+Review this change:
++- Does it correctly route interrupts to the right VMID/PASID?
++- Are TRAP and EOP interrupts handled distinctly?
++- Are cookie fields initialized for all interrupt sources?
++- What happens with concurrent interrupts from different VMIDs?
+```
+
+## PM4 packet processor
+```
+Review this change:
++- Does packet parsing handle all required PM4 opcodes?
++- Are MAP_PROCESS, RUN_LIST, INDIRECT_BUFFER handled correctly?
++- Is VMID/PASID tracking correct across packet boundaries?
++- Are unrecognized packets explicitly rejected?
+```
+
+## Cache / TLB
+```
+Review this change for cache/TLB coherence:
++- Does invalidation cover all required cache levels?
++- Is the scope (single page vs full flush) correct?
++- Are there races between invalidation and concurrent access?
++- Does the change match the corresponding hardware spec?
+```
+
+## HSA / Completion signal
+```
+Review this change:
++- Is done_event scheduled exactly once across all paths?
++- Is memory ownership clear (no leaks, no double-free)?
++- Are interruptible and non-interruptible paths consistent?
++- Does the change handle FullSystem and non-FullSystem modes equivalently?
+```
+
+## Common task patterns from cosim sessions
+
+| Task type | Example assignment scope |
+|-----------|-------------------------|
+| Source edit | "Add `_vmid` field to SDMAQueue, mirror the PM4Queue pattern" |
+| Source elimination | "Remove `lastVMID()` calls from pm4_packet_processor.cc, replace with captured/queue-owned VMID" |
+| Adversarial review | "Review interrupt_handler.cc CP_EOP changes: VMID routing, cookie init, concurrent VMID handling" |
+| Race review | "Review finding F7: `lastVMID()` race between doorbell map and MQD DMA callback. Is the captured_vmid fix complete?" |
+| Code investigation | "Search gem5/src/dev/amdgpu/ for VFIO_USER_REGION_READ handling. Map all code paths." |

--- a/.agents/skills/cosim-gpu-debug/SKILL.md
+++ b/.agents/skills/cosim-gpu-debug/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: cosim-gpu-debug
+description: "Use as the main entry for cosim debugging: gem5 crashes, assertions, hangs, timeouts, address translation faults, non-PASS test results, guest-side waits, and QEMU exits that may be secondary to gem5. Collect logs, preserve live state when needed, route to gem5 model references, and decide the first failing component."
+---
+
+# Cosim Debug
+
+Use this skill as the debugging entry point for non-PASS cosim behavior. Keep
+the workflow evidence-first: identify the authoritative artifact, decide the
+first failing component, then read only the reference that matches the observed
+mechanism.
+
+## Entry Guard
+
+For debug requests, use this workflow directly. Do not search for retired debug
+skills or older routing names. Translate historical dialogue into concrete
+evidence fields: artifact path, failing command, program identity, run id,
+environment row, first durable failure, live wait state, comparison row, and
+source mechanism under inspection.
+
+Environment variable questions are not debug evidence by themselves. Use
+`cosim-gpu-test` for runner prefix handling and `cosim-gpu-rocm-stack` for ROCm meaning.
+Return here when the environment row produces a non-PASS result or a live wait
+state.
+
+## Evidence Authority
+
+Use `cosim-gpu-info-gathering` for broad artifact intake, prior conversation
+review, or any task that may otherwise require scanning many logs. This debug
+skill should reason from the compact evidence map before opening raw logs.
+
+Start by classifying the artifact state:
+
+| Artifact state | Action |
+|---|---|
+| `verdict.json`, `matrix.tsv`, and `patch/binary-provenance.txt` exist | Treat archived files as authority. |
+| Runner row is incomplete and a matching process is alive | Take bounded live samples only when the active plan allows it. |
+| Runner row is incomplete and dead | Rerun only the accepted manifest row through `cosim-gpu-test`. |
+| Old row lacks gem5 log needed for ownership | Create a fixed rerun row with the same program, environment, timeout, and binary. |
+| QEMU-visible failure has no matching gem5 evidence | Classify as provisional until gem5 log is available. |
+
+Record the exact source and binary provenance before accepting any build or
+test evidence. Use `cosim-gpu-build` for build rules; do not duplicate its checks
+here.
+
+## Observable Event Routing
+
+For timeout, wait, and non-PASS rows, prefer a compact event summary before
+reading broad logs. Debug flags such as `GPUWgProgress`,
+`HSAPacketProcessor`, and `GPUCommandProc` are event sources, not the
+classification model. Different logs may fill the same observation dimension.
+
+Use `references/analysis/observable-dimensions.md` to map available logs into
+standard dimensions:
+
+- progress: dispatch count, completion count, active wave state
+- queue: read pointer, write pointer, dispatch pointer, packet completion
+- signal: completion signal address, signal write, interrupt or event wakeup
+- pressure: SQC retry, Ruby rejection, BufferFull, DMA or cache backpressure
+- failure: fatal, panic, assertion, translation fault, QEMU exit
+
+The preferred artifact tables are `coverage.tsv`, `progress.tsv`,
+`queue.tsv`, `signals.tsv`, and a short `diagnostic-summary.tsv`. Blank
+dimensions mean the evidence was not collected; `UNEXPLAINED` means the
+dimension was checked and no useful difference was found. Missing dimensions
+should guide the next minimal debug flag rather than trigger broad log reads.
+
+## Common Evidence Workflow
+
+Collect these facts before proposing a source edit:
+
+- Program path, run id, interrupt mode, timeout value, and exact runner command.
+- Full gem5 log, QEMU log, guest log, verdict, matrix row, and binary
+  provenance.
+- First durable failure line and the last 50-100 relevant lines before it.
+- Nearest passing comparison or a note explaining why none exists.
+- First object that differs: packet id, queue id, doorbell offset, signal
+  address, PASID, VMID, GPU virtual address, physical address, PTE value,
+  callback id, or interrupt cookie.
+
+Use focused searches first:
+
+```bash
+rg -n 'fatal|panic|assert|PM4|SDMA|VMID|PASID|doorbell|interrupt|signal|GART|PTE|translation|fault|timeout|Broken pipe|error_setv' \
+  <artifact>/logs/gem5.log <artifact>/logs/qemu.log <artifact>/logs/guest
+```
+
+## Component Decision
+
+Choose the next action from the first durable evidence:
+
+| Evidence | Action |
+|---|---|
+| gem5 log ends with `fatal`, `panic`, assertion, or container exit | Inspect gem5 logs and load `references/gem5-model/overview.md`. |
+| QEMU shows `error_setv`, vfio-user abort, socket close, or `Aborted` while gem5 may have exited | Treat QEMU as secondary until `references/qemu/error-setv-pattern.md` and gem5 logs say otherwise. |
+| gem5 log shows `User translation fault`, `GART`, unmapped page, VMID/PASID, PTE, or doorbell evidence | Load `references/gem5-model/address-translation-fault.md`. |
+| Workload is alive but output and progress counters stop changing | Keep the guest alive and load `references/analysis/live-wait-state.md`. |
+| Workload times out while dispatch and completion keep changing | Classify as throughput, scale, or timeout-budget evidence before editing model code. |
+| Non-PASS result has no crash | Use `references/analysis/debug-analysis.md` and `references/analysis/observable-dimensions.md`. |
+| cache, signal, PM4, VMID, PASID, SDMA, TLB, or PWC appears in logs | Load the matching gem5 model reference. |
+
+For the known MAP_QUEUES VMID assertion, inspect:
+
+```bash
+grep -n 'assert.*vmid\|assert(queue_vmid)\|MAPQueues' \
+  gem5/src/dev/amdgpu/pm4_packet_processor.cc
+```
+
+Then read:
+
+- `references/gem5-model/vmid-assert-lesson.md`
+- `references/gem5-model/examples/vmid-assert-crash.md`
+- `references/gem5-model/vmid-pasid-architecture.md`
+
+## Timeout and Wait Workflow
+
+Read `references/analysis/debug-workflows.md` for timeout, wait-state, and
+throughput workflows after the artifact summary identifies the missing
+dimension or live state.
+
+## Performance Optimization Workflow
+
+Read `references/analysis/debug-workflows.md` when the active objective is
+simulator efficiency rather than functional correctness.
+
+## Address Translation Fault Review
+
+Use this when gem5 shows `User translation fault`, `GART cosim`, unmapped page,
+PTE diagnostics, VMID/PASID mismatch, or unknown doorbell evidence near a
+crash. Read `references/gem5-model/address-translation-fault.md`.
+
+Minimum notes before editing:
+
+- failing program, run id, HSA interrupt value, and nearest passing row
+- first gem5 fatal line and any secondary QEMU socket or `error_setv` symptom
+- faulting GPU virtual address, physical address if any, PTE value, GART base,
+  page-table base, VMID, PASID, queue id, and doorbell offset
+- PM4, SDMA, or HSA packet sequence immediately before the failing translation
+- whether the fault is deterministic across interrupt modes
+
+QEMU `error_setv`, EOF, broken pipe, and device-lost messages are secondary
+when gem5 logs contain an earlier translation fatal for the same run id.
+
+## Script Discipline
+
+Read `references/analysis/debug-workflows.md` before adding debug scripts or
+source instrumentation.
+
+## Guest Inspection
+
+Use `cosim-gpu-guest` for console transport and guest command injection. Gather:
+
+- PCI device state for the emulated GPU
+- loaded amdgpu module state
+- `cosim-gpu-setup.service` status
+- ROCm device visibility and agent enumeration
+- full and filtered kernel logs
+- target process id, thread table, wait channel, kernel stacks, file
+  descriptors, and user-space backtrace when the target remains live
+
+## Patch Readiness
+
+Read `references/analysis/debug-workflows.md` before deciding that a source edit
+is ready.
+
+## QEMU Trace
+
+Trace the standard vfio-user transport when QEMU-side protocol evidence is
+needed:
+
+```bash
+./scripts/cosim_launch.sh --qemu-trace 'vfio_user_*'
+```
+
+Record the exact launch command and trace log with the run artifacts.
+
+## References
+
+- `references/analysis/debug-analysis.md` - fact recording and comparison guide
+- `references/analysis/observable-dimensions.md` - observable dimensions checklist
+- `references/analysis/live-wait-state.md` - live guest wait-state sampling
+- `references/analysis/debug-workflows.md` - timeout, performance, script, and patch-readiness workflows
+- `references/gem5-model/overview.md` - gem5 MI300X model map
+- `references/gem5-model/discovery-log.md` - prior model discoveries
+- `references/gem5-model/cache-coherence-checkpoints.md` - TLB, PWC, SQC, GL2 checkpoints
+- `references/gem5-model/address-translation-fault.md` - GART, PTE, VMID/PASID, and doorbell fault review
+- `references/gem5-model/hsa-signal-completion-pattern.md` - HSA signal completion design
+- `references/gem5-model/vmid-pasid-architecture.md` - VMID/PASID semantics
+- `references/gem5-model/vmid-assert-lesson.md` - MAP_QUEUES VMID assertion lesson
+- `references/qemu/qemu-first-failure.md` - QEMU-first failure reference
+- `references/qemu/error-setv-pattern.md` - QEMU error propagation pattern

--- a/.agents/skills/cosim-gpu-debug/references/analysis/debug-analysis.md
+++ b/.agents/skills/cosim-gpu-debug/references/analysis/debug-analysis.md
@@ -1,0 +1,75 @@
+# Debug Analysis Reference
+
+Use this reference after `cosim-gpu-debug` has collected the first log set. The goal
+is to keep analysis concrete: name the observed behavior, compare it with a
+nearby passing run when possible, map the difference to a model mechanism, and
+only then edit source.
+
+## Record the observed behavior
+
+Write these fields in the case notes:
+
+- target program and exact relative path
+- launch command and artifact directory
+- verdict, exit code, timeout status, or crash text
+- interrupt mode and other test variables
+- guest-visible object when known: signal address, queue, packet, buffer,
+  VMID, PASID, interrupt cookie, or wait channel
+- log paths and line ranges that prove the behavior
+
+If the guest-visible object is unknown, add read-only markers or collect guest
+state again before editing source.
+
+## Compare with a passing run
+
+Prefer the nearest passing run in this order:
+
+1. same program with another interrupt mode
+2. same program on an earlier gem5 commit
+3. different program that exercises the same API and completion path
+4. minimal baseline such as `vector_add` only when it uses the relevant path
+
+The comparison must use the same launcher, binaries, backend, and device setup
+unless that variable is the point of the test.
+
+## Count differences
+
+Count named differences instead of relying on broad impressions:
+
+- signal and interrupt writes
+- PM4 packet sequence
+- DMA records
+- VMID and PASID values
+- address translation paths
+- cache maintenance events
+- wait channels and user-space backtraces for hangs
+
+Use `observable-dimensions.md` as the checklist for visible boundaries. Do not
+turn the checklist into a staged process.
+
+## Map difference to mechanism
+
+Every proposed source edit needs a mechanism with a concrete file and function.
+Useful references:
+
+- `../gem5-model/overview.md`
+- `../gem5-model/cache-coherence-checkpoints.md`
+- `../gem5-model/vmid-pasid-architecture.md`
+- `../gem5-model/hsa-signal-completion-pattern.md`
+- `../gem5-model/discovery-log.md`
+
+For QEMU exits that follow a gem5 crash, use `../qemu/error-setv-pattern.md`
+only to explain the secondary symptom.
+
+## Edit and verify
+
+Before editing source, record:
+
+- failing evidence before the change
+- source location and mechanism
+- intended behavior after the change
+- verification rows, including the original failure and at least one nearby
+  passing baseline
+
+After editing, run the same test path through the standard runner so binary
+provenance and source checks are regenerated.

--- a/.agents/skills/cosim-gpu-debug/references/analysis/debug-workflows.md
+++ b/.agents/skills/cosim-gpu-debug/references/analysis/debug-workflows.md
@@ -1,0 +1,86 @@
+# Debug Workflows
+
+Read this from `cosim-gpu-debug` after the first durable evidence identifies a
+timeout, wait state, performance objective, or source-edit candidate.
+
+## Timeout And Wait
+
+Separate timeout evidence into three classes:
+
+- No guest business output: verify build, executable path, runtime loader, and
+  guest command before model debugging.
+- Guest output advances to a named workload phase: add bounded dispatch and
+  completion progress diagnostics.
+- Dispatch/completion counters advance until timeout: treat it as scale or
+  model-throughput evidence unless a later snapshot shows a fixed wait state.
+
+For long timeout rows, use script-produced summaries when available. Read raw
+log windows only after the summary names a missing dimension or a specific
+event source and line range.
+
+For known wait-state investigation, do not use the normal timeout wrapper. It
+can kill the target process that holds useful state. Use `cosim-gpu-guest` and
+take two bounded samples that agree on process id, thread states, wait
+channels, kernel stacks, user-space backtraces, and absence of new target
+output.
+
+Choose the next debug flag from the missing dimension:
+
+| Missing dimension | Minimal next source |
+|---|---|
+| dispatch or completion count | `GPUWgProgress` |
+| queue read/write or packet completion | `HSAPacketProcessor` |
+| completion signal write or EOP path | `GPUCommandProc` |
+| fetch retry or Ruby rejection | SQC/Ruby focused flags |
+| live userspace wait state | `cosim-gpu-guest` live wait sampling |
+
+## Performance Optimization
+
+Use this when the active objective is simulator efficiency rather than
+functional correctness. Keep the parent goal and candidate stage separate: a
+candidate can be evaluated and rejected while the broader search remains active.
+
+Before proposing a performance patch, build four evidence views when available:
+host CPU profile, gem5 event or callback breakdown, Ruby/GPU path counters, and
+guest workload timing. Separate guest boot and runner framework time from the
+target workload window.
+
+For each candidate, use one isolated worktree, one explicit gem5 binary, one
+per-row output directory, one candidate-only diff, and one full reconstructable
+diff.
+
+Rank candidates by end-to-end effect, not by local counter reduction alone. If
+a candidate reduces a hot function, event, or callback but runner wall time or
+workload window remains flat, record it as local cleanup or secondary
+optimization.
+
+For event-loop or polling changes, preserve protocol progress semantics. A
+candidate that reduces empty calls but increases scheduler events, fails boot,
+or changes vfio-user progress behavior is rejected unless a follow-up row proves
+both PASS and end-to-end improvement.
+
+## Script Discipline
+
+- Prefer existing repository scripts: `scripts/cosim_build.sh`,
+  `scripts/run_cosim_tests.sh`, `scripts/cosim_launch.sh`, and
+  `scripts/cosim_cleanup.sh`.
+- Prefer fixed manifest rows over ad hoc loops.
+- Add parameters only when the evidence needs them and record each value in the
+  artifact.
+- Do not bypass provenance hooks.
+- Preserve runner exit code, verdict, matrix row, and logs.
+- Keep diagnostic source instrumentation behind debug flags when possible.
+
+## Patch Readiness
+
+A source edit is ready only when notes identify:
+
+- failing command and exact program path
+- first failing component, with log lines or backtrace
+- nearest passing comparison or reason no comparison exists
+- observed object that differs
+- source location implementing the relevant mechanism
+- verification plan using the same test runner and provenance checks
+
+Use diff-scoped formatting for behavior fixes. Do not mix broad formatting with
+debugging changes.

--- a/.agents/skills/cosim-gpu-debug/references/analysis/live-wait-state.md
+++ b/.agents/skills/cosim-gpu-debug/references/analysis/live-wait-state.md
@@ -1,0 +1,81 @@
+# Live Wait-State Sampling
+
+Use this reference when a target is alive but no longer makes progress. The
+goal is to preserve the wait object and capture two comparable state samples.
+
+## Launch Rule
+
+Do not run the normal test timeout wrapper for a known wait-state
+investigation. It can kill the process that contains the evidence.
+
+Use the runner only to create the live environment:
+
+```bash
+scripts/run_cosim_tests.sh --hang-env --output-dir <case_dir> <program>
+```
+
+Build the exact guest command from the target identity already proven by
+`cosim-gpu-test`:
+
+- local kernel: `cd /mnt/tests && ./build/<program>`
+- ROCm example: `cd /mnt/external/rocm-examples/<case-dir> && ./<built-binary>`
+
+## Guest Session
+
+Before starting the target, verify that `tmux` exists in the guest as root:
+
+```bash
+printf '%s\n' "${COSIM_GUEST_SUDO_PASSWORD:?set COSIM_GUEST_SUDO_PASSWORD}" | sudo -S bash -lc 'command -v tmux'
+```
+
+If this fails, mark the disk image or guest setup invalid for live wait-state
+debugging.
+
+Use a root-owned guest `tmux` session:
+
+```bash
+printf '%s\n' "${COSIM_GUEST_SUDO_PASSWORD:?set COSIM_GUEST_SUDO_PASSWORD}" | sudo -S bash -lc \
+  'tmux kill-session -t cosim-hang 2>/dev/null || true
+   tmux new-session -d -s cosim-hang -n reproduce "<exact-target-command>; echo EXIT:\$?; exec bash"
+   tmux new-window -t cosim-hang -n debug "cd /mnt && bash"'
+printf '%s\n' "${COSIM_GUEST_SUDO_PASSWORD:?set COSIM_GUEST_SUDO_PASSWORD}" | sudo -S tmux attach -t cosim-hang
+```
+
+ROCm programs that open `/dev/kfd` or `/dev/dri/renderD*` must run with the
+same privilege level as the test runner. A plain-user launch is invalid for
+these targets because it can change ROCm device visibility.
+
+## Sample Contents
+
+Inside the debug window:
+
+```bash
+pgrep -af <program>
+ps -T -p <pid>
+cat /proc/<pid>/stack
+gdb -batch -p <pid> -ex "thread apply all bt"
+```
+
+Capture two bounded samples 10-20 seconds apart. Each sample must include:
+
+- target log tail
+- full `dmesg`
+- filtered `dmesg` for `amdgpu|kfd|drm|irq|ih|fault|vmid|pasid`
+- process id, thread ids, and thread states
+- per-thread `wchan`
+- per-thread kernel stacks
+- file descriptors
+- user-space backtrace
+
+Treat the wait state as proven only when both samples show the same live
+process, no new target output, the same blocking thread set, compatible wait
+channels, and compatible user-space backtraces.
+
+## Shutdown
+
+After evidence is saved, shut down the guest through the console pipe with root
+privileges:
+
+```bash
+printf '%s\n' "printf '%s\n' \"\${COSIM_GUEST_SUDO_PASSWORD:?set COSIM_GUEST_SUDO_PASSWORD}\" | sudo -S poweroff" > "$CONSOLE_PIPE"
+```

--- a/.agents/skills/cosim-gpu-debug/references/analysis/observable-dimensions.md
+++ b/.agents/skills/cosim-gpu-debug/references/analysis/observable-dimensions.md
@@ -1,0 +1,149 @@
+# Observable Dimensions
+
+Which observable dimensions to compare between working and failing cases.
+Read with `../gem5-model/` references for source-level checkpoints.
+
+## Event Model
+
+Do not bind analysis to one debug flag's text format. Convert available logs
+into a small event model first, then reason from the event tables.
+
+Recommended event row:
+
+```text
+row_id	event_type	source	line	object_id	value	confidence
+```
+
+`event_type` should be one of:
+
+- `progress.dispatch`
+- `progress.complete`
+- `progress.active_wave`
+- `queue.read_ptr`
+- `queue.write_ptr`
+- `queue.dispatch_ptr`
+- `queue.packet_complete`
+- `queue.barrier_state`
+- `signal.addr`
+- `signal.write`
+- `signal.interrupt`
+- `pressure.fetch_retry`
+- `pressure.ruby_reject`
+- `failure.fatal`
+- `failure.assert`
+- `failure.translation`
+- `failure.qemu_exit`
+
+Different debug flags may produce the same event type. For example, a workgroup
+progress log and a packet processor log can both prove that execution advanced;
+they should fill the same progress dimension rather than create separate
+classification rules.
+
+## Compact Tables
+
+Generate these small tables when possible:
+
+```text
+coverage.tsv: row_id dimension status source
+filter_coverage.tsv: row_id filter_name filter_expr covered_min covered_max observed_min observed_max uncovered_count status
+progress.tsv: row_id kernel_id dispatched completed last_change_line rate_hint
+queue.tsv: row_id queue_id read_ptr write_ptr dispatch_ptr barrier_state last_event
+signals.tsv: row_id signal_addr wrote_signal interrupt_seen source
+```
+
+`status` values:
+
+- `observed`: dimension has concrete evidence
+- `missing`: not collected
+- `unexplained`: checked, no useful difference found
+
+Agents should read `coverage.tsv` and `diagnostic-summary.tsv` before opening
+large logs.
+
+`filter_coverage.tsv` is required whenever instrumentation or log extraction
+uses object filters such as sequence ranges, queue ids, kernel ids, CU ids,
+wavefront ids, addresses, or packet ids. A negative observation is valid only
+when `uncovered_count` is zero for the final objects being explained.
+
+## Signal / Interrupt
+
+| Signal | Working | Failing |
+|--------|---------|---------|
+| EOP interrupts | N | M |
+| Trap interrupts | N | M |
+| Completion signals | N | M |
+
+## PM4 packets
+
+| Packet type | Working count | Failing count |
+|-------------|---------------|---------------|
+| MAP_PROCESS | N | M |
+| RUN_LIST | N | M |
+| WRITE_DATA | N | M |
+| INDIRECT_BUFFER | N | M |
+| RELEASE_MEM | N | M |
+
+## Translation / VMID
+
+| Dimension | Working | Failing |
+|-----------|---------|---------|
+| VMID at last EOP | N | M |
+| PASID at signal write | N | M |
+
+## Cache coherence
+
+| Cache layer | Working invalidation count | Failing invalidation count |
+|-------------|---------------------------|----------------------------|
+| PWC (page walk cache) | N | M |
+| TLB (per-VMID) | N | M |
+| SQC (scalar L1) | N | M |
+| GL2 / L2 | N | M |
+
+## Memory / dispatch
+
+| Dimension | Working | Failing |
+|-----------|---------|---------|
+| Kernarg pages mapped | N | M |
+| Dispatch grid size / dims | N | M |
+| Signal addresses allocated | N | M |
+| Workgroups dispatched | N | M |
+| Workgroups completed | N | M |
+| Progress still changing | yes/no | yes/no |
+
+## Queue / packet state
+
+| Dimension | Working | Failing |
+|-----------|---------|---------|
+| HSA queue read pointer | N | M |
+| HSA queue write pointer | N | M |
+| HSA dispatch pointer | N | M |
+| Packet completion observed | yes/no | yes/no |
+| Barrier state after completion | clear/set | clear/set |
+
+## Pressure / throughput
+
+| Dimension | Working | Failing |
+|-----------|---------|---------|
+| SQC fetch retry count | N | M |
+| Ruby rejection count | N | M |
+| DMA or cache backpressure | N | M |
+| Estimated completion time | seconds | seconds |
+
+## Source checkpoints
+
+For exact gem5 file:line references per cache/translation layer, use
+`../gem5-model/cache-coherence-checkpoints.md`.
+
+## Completeness rule
+
+Each relevant dimension must have a value or `UNEXPLAINED` before a source edit.
+`UNEXPLAINED` means no difference was found after checking that dimension.
+A blank value means the observation has not been collected yet.
+
+`coverage_insufficient` means the diagnostic ran but did not cover the final
+objects that matter. It is not equivalent to `UNEXPLAINED` and must not be used
+as evidence that an event was absent.
+
+For timeout rows, a source edit is not ready if the only fact is
+`TIMEOUT_WAIT`. First determine whether progress still changes, all GPU work
+completed before host wait, or the row lacks enough observation coverage.

--- a/.agents/skills/cosim-gpu-debug/references/gem5-model/address-translation-fault.md
+++ b/.agents/skills/cosim-gpu-debug/references/gem5-model/address-translation-fault.md
@@ -1,0 +1,92 @@
+# Address Translation Fault Review
+
+Use this reference when gem5 reports user translation faults, GART diagnostics,
+unmapped pages, PTE anomalies, VMID/PASID mismatches, or doorbell activity near
+a crash.
+
+## Trigger Evidence
+
+Load this reference for any of these log patterns:
+
+```text
+fatal: User translation fault
+GART cosim
+unmapped page
+PTE[
+Unknown doorbell offset
+VMID
+PASID
+```
+
+QEMU `error_setv`, vfio-user EOF, broken pipe, and device-lost messages are
+secondary if a matching gem5 fatal line exists earlier in the same run id.
+
+## Required Facts
+
+Record these facts in the active evidence file before proposing a source edit:
+
+- Program identity, run id, interrupt mode, test timeout, and exact runner
+  command.
+- First gem5 fatal line and the last 50-100 gem5 lines before it.
+- Faulting GPU virtual address, translated physical address if present, PTE
+  value, GART base, page-table base, framebuffer base/top, and VRAM size.
+- VMID, PASID, queue id, queue base, doorbell offset, and packet id if present.
+- Last PM4, SDMA, or HSA packet before the failing translation.
+- Whether the same fault repeats across `HSA_ENABLE_INTERRUPT=0` and `1`.
+- Nearest passing comparison that uses the same launch path and binary
+  provenance.
+
+## Log Extraction
+
+Use focused searches first:
+
+```bash
+rg -n 'fatal: User translation fault|GART cosim|unmapped page|PTE\[|Unknown doorbell|VMID|PASID|doorbell|MAP|DISPATCH|SDMA|PM4' \
+  <artifact>/logs/gem5.log <artifact>/logs/qemu.log
+```
+
+If the per-row gem5 log contains only a Docker lookup error, find the matching
+launcher-side artifact by `run_id` under `artifacts/standalone/<run_id>/` and
+copy its `logs/gem5.log` into the active task artifact directory. Treat the
+per-row missing log as an evidence capture issue, not as a program result.
+
+## Debug Flags
+
+Choose the smallest useful flag set:
+
+```bash
+--gem5-debug AMDGPUDevice,PM4PacketProcessor
+```
+
+Add these only when the baseline evidence points there:
+
+```bash
+--gem5-debug SDMAEngine
+--gem5-debug HSAPacketProcessor
+--gem5-debug MI300XCosim
+```
+
+Avoid broad debug flags until a small set has proven insufficient. Large logs
+can hide the first object that differs.
+
+## Interpretation Rules
+
+- A GART unmapped-page warning followed by `fatal: User translation fault`
+  makes gem5 the first failing component unless an earlier QEMU abort exists.
+- An unknown doorbell offset before the fault is adjacent evidence, not a
+  source cause by itself. Tie it to a queue id, packet sequence, or VMID/PASID
+  mismatch before editing.
+- Symmetric results across interrupt modes reduce the likelihood of an
+  interrupt-completion-only cause.
+- A QEMU `error_setv` assertion after gem5 exits belongs in the notes as a
+  secondary defensive failure.
+
+## Patch Readiness
+
+A source edit is ready only when the notes identify:
+
+- the address or PTE object that first differs from a passing comparison
+- the code path that should have created, updated, invalidated, or translated
+  that object
+- the verification rows, including the failing workload and one nearby passing
+  workload

--- a/.agents/skills/cosim-gpu-debug/references/gem5-model/cache-coherence-checkpoints.md
+++ b/.agents/skills/cosim-gpu-debug/references/gem5-model/cache-coherence-checkpoints.md
@@ -1,0 +1,55 @@
+# Cache Coherence Checkpoints
+
+Use this reference when `cosim-gpu-debug` evidence points at cache-coherence or
+translation behavior. These are source-level checkpoints for gem5 model
+inspection; they are not a replacement for per-case evidence.
+
+## PWC and TLB
+
+Question:
+- Does the invalidation path clear final TLB entries and page-walk-cache state?
+- Does the path cover the VMID or address range used by the failing sample?
+
+Checkpoints:
+- `gem5/src/arch/amdgpu/vega/tlb.cc`: `GpuTLB::invalidateAll()` should reach PWC invalidation when the current branch requires full translation maintenance.
+- `gem5/src/arch/amdgpu/vega/pagetable_walker.cc`: `Walker::invalidatePWC()` is the page-walk-cache invalidation entry.
+- `gem5/src/dev/amdgpu/amdgpu_vm.cc`: GPU VM invalidation routes driver-visible invalidation events to registered GPU TLBs.
+
+Evidence to record:
+- TLB invalidation count.
+- PWC invalidation count.
+- VMID or address scope.
+- Last translation state before the failed signal, packet, or memory access.
+
+## Kernarg Physical Range Capture
+
+Question:
+- Did dispatch setup record the physical ranges backing the kernarg segment?
+- Are system-memory kernarg ranges distinguished from device-memory ranges?
+
+Checkpoints:
+- `gem5/src/gpu-compute/gpu_command_processor.cc`: dispatch setup reads kernel metadata, translates kernarg ranges, and records them on the task.
+- `gem5/src/gpu-compute/hsa_queue_entry.hh`: task state stores kernarg address, size, and translated physical ranges.
+
+Evidence to record:
+- Kernarg virtual address and size.
+- Translated physical ranges.
+- Whether each range is system memory or device memory.
+- Dispatch id or task id that owns the range.
+
+## SQC and GL2 Maintenance
+
+Question:
+- Does dispatch-boundary maintenance cover the scalar path that will read kernarg data?
+- Does GL2 invalidation complete before shader execution starts?
+
+Checkpoints:
+- `gem5/src/gpu-compute/shader.cc`: `Shader::prepareInvalidate()` performs dispatch-boundary invalidation work before kernel execution.
+- `gem5/src/gpu-compute/compute_unit.cc`: `ComputeUnit::doSQCInvalidate()` and `handleSQCReturn()` cover SQC invalidation and completion.
+- `gem5/src/mem/ruby/system/VIPERCoalescer.cc`: TCC/GL2 invalidation callbacks show whether Ruby-side cache maintenance completed.
+
+Evidence to record:
+- SQC invalidation count and completion marker.
+- GL2/TCC invalidation count and callback order.
+- Shader execution start marker.
+- First CU scalar-load address for the kernarg path.

--- a/.agents/skills/cosim-gpu-debug/references/gem5-model/discovery-log.md
+++ b/.agents/skills/cosim-gpu-debug/references/gem5-model/discovery-log.md
@@ -1,0 +1,112 @@
+# Cosim gem5 AMD GPU Model — Discovery Log
+
+Record of coherence and correctness discoveries from cosim stability debugging (May 2026).
+Each entry captures what was found, the evidence that proved it, and where the fix was applied.
+Use these as routing hints for new debugging sessions; each new case still needs its own evidence.
+
+## 1. PWC not invalidated on full TLB flush
+
+**Discovery**: May 2026, RLCR round 4-6. Repeated vector_add execution caused TLB entries to be reused across
+sessions. `invalidateAll` cleared the TLB but not the page walk cache, so stale PTE fragments survived.
+
+**Evidence**: Two-snapshot state comparison showed TLB empty after `invalidateAll` but PWC still held entries
+matching the old page table. Next page walk returned stale PWC data without re-traversing.
+
+**Fix**: `gem5/src/arch/amdgpu/vega/tlb.cc` — conservative full PWC invalidation on every full TLB flush.
+Commit: `arch-amdgpu: invalidate PWC on full TLB flush`.
+
+**Verification**: 200× vector_add with PWC invalidation: 0 TIMEOUT_WAIT (was ~3% failure rate before fix).
+
+**Debug reference**: `cosim-gpu-debug` cache and translation evidence; see
+`overview.md` and `cache-coherence-checkpoints.md`.
+
+## 2. Kernarg L2 visibility gap
+
+**Discovery**: May 2026, RLCR round 7-8. Command processor (CP) wrote kernarg data through a path that bypassed
+GL2/L2, while compute unit (CU) scalar loads read through GL2. Stale L2 cache lines delivered old values.
+
+**Evidence**: CP-side kernarg dump (instrumented) showed correct values; CU-side scalar load trace showed different
+values for the same physical addresses. CP writes were systemReq (bypassing GPU GL2 path), CU reads went through
+Ruby VIPER L2.
+
+**Fix**: Track kernarg system memory ranges and invalidate GL2 cache lines for these ranges before kernel launch.
+PR: `zevorn/gem5#1`.
+
+**Verification**: `docs/silent_data_error_kernarg_l2_record.md` — kernarg validation pass after invalidation.
+
+**Debug reference**: `cosim-gpu-debug` cache evidence; see `overview.md` cache
+hierarchy and `cache-coherence-checkpoints.md`.
+
+## 3. QEMU↔gem5 memory coherence gap
+
+**Discovery**: May 2026. Under repeated execution, the ROCm runtime allocates new virtual addresses, reuses page
+table pages, and updates PTEs. QEMU and gem5 share guest RAM via `/dev/shm/cosim-guest-ram`, but there is no
+explicit coherence protocol: gem5 may see stale or missing PTEs if it accesses a page before QEMU's PTE update
+propagates through the shared memory.
+
+**Evidence**: Multiple instances of `TIMEOUT_WAIT` correlated with stale PTE values in gem5's TLB compared to
+current values in QEMU's shadow page table.
+
+**Status**: Partially addressed by PWC fix (#1 above) and cache coherence fixes (#2, #4). Full coherence
+protocol between QEMU and gem5 is deferred.
+
+**Debug reference**: `cosim-gpu-debug` translation and VMID evidence; see
+`cosim-gpu-rocm-stack` KFD ioctls for unmap triggers.
+
+## 4. ACQUIRE_MEM / RELEASE_MEM semantics incomplete
+
+**Discovery**: May 2026. The gem5 model recognized ACQUIRE_MEM and RELEASE_MEM PM4 packets but did not perform
+full cache maintenance. ACQUIRE_MEM with base=0, size=0xffffffffffffff00 (global) should invalidate code and
+data caches, but the model only processed it for code objects, missing data cache invalidation.
+
+**Evidence**: ROCm Compute Profiler documentation and gem5 PM4 packet traces showed ACQUIRE_MEM arriving before
+kernel execution but the invalidation scope was narrower than hardware behavior.
+
+**Status**: Investigated May 2026; fix scope reframed to specific cache-layer fixes (#1, #2) instead of full
+ACQUIRE_MEM/RELEASE_MEM implementation.
+
+**Debug reference**: `cosim-gpu-debug` PM4 packet comparison; see `overview.md`.
+
+## 5. SQC (scalar L1) not invalidated on kernel launch
+
+**Discovery**: May 2026. `prepareInvalidate` on kernel launch invalidated GL2 cache lines for kernarg ranges but
+did not reach SQC. Scalar loads that hit SQC after a prior kernel execution could return stale values even when
+GL2 was clean.
+
+**Evidence**: Instrumentation showed SQC hit counts for kernarg addresses after GL2 invalidation completed.
+Adding SQC invalidation eliminated residual wrong results.
+
+**Fix**: Extended `prepareInvalidate` to include SQC invalidation for kernarg ranges.
+
+**Debug reference**: `cosim-gpu-debug` cache evidence; see `overview.md` cache
+hierarchy.
+
+## 6. Interrupt VMID routing for multi-operation programs
+
+**Discovery**: May-June 2026. Programs with both kernel execution and hipFree experienced signal timeout because
+the RELEASE_MEM-triggered CP_EOP interrupt carried the wrong VMID. The driver's interrupt handler used the
+interrupt cookie VMID to route the signal completion, but the cookie was populated from the last known VMID
+rather than the correct MAP_PROCESS context.
+
+**Evidence**: hipFree signal address traced through gem5 showed correct write, but interrupt cookie had vmid=0
+instead of vmid=3. Driver received interrupt but could not match it to the waiting user process.
+
+**Fix**: `gem5/src/dev/amdgpu/interrupt_handler.cc` — track VMID from MAP_PROCESS rather than lastVMID.
+PR: `zevorn/gem5#4`.
+
+**Debug reference**: `cosim-gpu-debug` signal, interrupt, translation, and VMID
+evidence; see `overview.md` interrupt handling section.
+
+## Cross-cutting lessons
+
+1. **Cache coherence is layered**: Bug symptoms at one layer (signal timeout) often root-cause to another
+   (PWC holding stale PTE). Check all cache layers before concluding.
+
+2. **Repeated execution exposes coherence gaps**: Single-run tests mask stale-state bugs. Always verify with
+   repeated-program matrices.
+
+3. **CP vs. CU coherence domains**: The command processor and compute units access memory through different
+   paths. What CP writes may not be visible to CU without explicit invalidation.
+
+4. **Instrumentation must be non-invasive**: Adding debug prints that trigger cache lookups, TLB walks, or
+   packet processing can change the failure pattern. Prefer passive observation on existing paths.

--- a/.agents/skills/cosim-gpu-debug/references/gem5-model/examples/signal-completion-debug.md
+++ b/.agents/skills/cosim-gpu-debug/references/gem5-model/examples/signal-completion-debug.md
@@ -1,0 +1,43 @@
+# HSA Signal Completion Debug (June 2026)
+
+Four rounds of Codex adversarial review converged `sendCompletionSignal` from
+"embarrassingly temporary" to "clean, approaching elegant."
+
+## When you'll hit this again
+
+- Adding a new signal completion path that needs deferred resource cleanup
+- Reviewing code where `done_event` is threaded through multiple layers
+- Debugging hipFree hangs after h2d→launch→d2h succeeds
+
+## The problem
+
+`submitVendorPkt` initiates a DMA chain that writes the HSA completion signal.
+The packet must not be freed (`finishPkt`) until DMA completes. Original fix
+threaded a bare `Event *done_event` through 6 public functions.
+
+## Convergence
+
+| Round | Rating | Finding |
+|-------|--------|---------|
+| 1 | Embarrassingly temporary | done_event through 6 public layers = parameter bloat |
+| 2 | Acceptable but rough | Making functions private hides but doesn't fix coupling |
+| 3 | Conditionally passes | Need single public entry, unique_ptr for buffers, explicit ownership |
+| 4 | Clean, approaching elegant | Structure sound; remaining items are hygiene |
+
+## Key insight
+
+`dispatchStartTime[signal_handle]` with bare `[]` default-constructs zero-value
+entries on missing keys — use `find()` instead. This was the pre-existing bug
+that hipFree hang exposed: heap layout changes from the refactor shifted the
+map's bucket distribution, creating a new zero-value entry that triggered an
+unexpected early `finishPkt`.
+
+## Artifacts
+
+- `artifacts/fix-hsa-signal-ih-completion-2/` — RLCR workspace with all 4 rounds
+- Session `~/.omp/agent/sessions/-cosim-gpu/2026-06-21T15-23-16-042Z*.jsonl` — full review dialogue
+
+## Cross-references
+
+- `../hsa-signal-completion-pattern.md` — final design pattern
+- `../vmid-pasid-architecture.md` — call site semantics

--- a/.agents/skills/cosim-gpu-debug/references/gem5-model/examples/vmid-assert-crash.md
+++ b/.agents/skills/cosim-gpu-debug/references/gem5-model/examples/vmid-assert-crash.md
@@ -1,0 +1,38 @@
+# VMID Assert Crash (June 2026)
+
+`assert(queue_vmid)` in PM4 MAP_QUEUES caused gem5 crash, masking a QEMU
+double-error bug in vfio-user proxy.c.
+
+## When you'll hit this again
+
+- gem5 dies with assertion failure during GPU init
+- QEMU crashes with `error_setv` SIGABRT immediately after
+- `fix-hsa-signal-ih-completion-2` or any branch with `assert(pkt->vmid)`
+- The `fix-hsa-signal-only` branch (`8680505b71`) does NOT have this bug
+
+## First failing mechanism
+
+Commit `aa5d08d97773` replaced `lastVMID()` fallback with `assert(queue_vmid)`.
+The amdgpu driver sends MAP_QUEUES with `pkt->vmid == 0` (by KFD design —
+VMID is in the MQD, not the packet). The assertion was premature.
+
+## Key decision path
+
+Initially suspected QEMU `error_setv` bug as the first failure. GDB backtrace showed
+the double-error in `vfio_user_recv_hdr`. But fixing QEMU only stopped the
+crash — GPU still failed to init. Tracing backwards revealed gem5 was dying
+first, QEMU was a secondary effect.
+
+The lesson: always find the first component to fail, not the last visible assertion.
+
+## Artifacts
+
+- `artifacts/fix-hsa-signal-ih-completion-2/` — full RLCR review workspace
+- `artifacts/pr4-qemu-error-setv-debug/` — QEMU GDB debugging session
+- `artifacts/pr4-rlcr-signal-vmid/` — RLCR rounds for signal+VMID fix
+
+## Cross-references
+
+- `../vmid-pasid-architecture.md` — why pkt->vmid==0 is correct
+- `../../qemu/error-setv-pattern.md` — error_setv mechanism
+- `../../analysis/observable-dimensions.md` — observable dimension checklist

--- a/.agents/skills/cosim-gpu-debug/references/gem5-model/hsa-signal-completion-pattern.md
+++ b/.agents/skills/cosim-gpu-debug/references/gem5-model/hsa-signal-completion-pattern.md
@@ -1,0 +1,93 @@
+# HSA Signal Completion Pattern
+
+Design pattern for threading completion callbacks through the HSA signal DMA
+chain. Converged through 4 rounds of independent Codex adversarial review on
+`fix-hsa-signal-only` (June 2026).
+
+## Problem
+
+A vendor packet (`submitVendorPkt`) initiates a completion signal DMA chain that
+writes the HSA signal value to guest memory. The packet must not be released
+(`finishPkt`) until the DMA chain completes — otherwise use-after-free.
+
+The original fix threaded a bare `Event *done_event` pointer through 6 layers of
+public functions, each gaining an extra parameter. This was rejected as parameter
+bloat and cross-layer coupling.
+
+## Converged design
+
+Single public entry point. Internal chain is entirely private.
+
+```cpp
+// gpu_command_processor.hh — public
+void sendCompletionSignal(Addr signal_handle, Event *done_event = nullptr);
+
+// gpu_command_processor.hh — private
+#include <memory>
+
+struct HsaSignalUpdateContext {
+    // Immutable — set at construction
+    Addr signal_handle;
+    int64_t diff = -1;           // completion signal always decrements by 1
+    Tick start_ts = 0;
+
+    // Mutable — accumulated during DMA chain
+    std::unique_ptr<uint8_t[]> tmp;  // heap buffer, auto-cleanup on destruction
+
+    // Caller-owned — ctx only schedules, never deletes
+    Event *done_event = nullptr;
+
+    void notify(GPUCommandProcessor *proc);    // FullSystem vs SE branching
+    void complete(GPUCommandProcessor *proc);  // schedule(done_event) + delete this
+};
+
+// Private chain (all called only from within the struct or gpu_command_processor):
+//   sendCompletionSignal → ctx = new HsaSignalUpdateContext
+//     → updateHsaSignalAsync(ctx)
+//       → updateHsaMailboxData(ctx)
+//         → updateHsaEventData(ctx)
+//           → updateHsaEventTs(ctx)
+//             → updateHsaSignalData(ctx)
+//               → ctx->notify(this)     // encapsulate FullSystem/SE branching
+//               → ctx->complete(this)   // schedule(done_event) + delete this
+```
+
+## Call site semantics
+
+Four call sites pass `sendCompletionSignal`. The distinction is not DMA vs
+non-DMA (all paths go through DMA); it is **who needs resource cleanup after
+DMA completes**:
+
+| # | Call site | File | `done_event` | Reason |
+|---|-----------|------|-------------|--------|
+| 1 | `submitVendorPkt` | `gpu_command_processor.cc` | **non-null** | Signal DMA completes → must `finishPkt` to release packet |
+| 2 | `dispatchKernelObject` | `gpu_command_processor.cc` | `nullptr` | Only writes completion signal; no packet to release |
+| 3 | `notifyWgCompl` | `dispatcher.cc` | `nullptr` | Workgroup completion notification; no resource to defer-clean |
+| 4 | barrier packet | `hsa_packet_processor.cc` | `nullptr` | Doorbell-triggered; no packet lifecycle involved |
+
+## Review convergence
+
+The design was iterated through 4 rounds of independent Codex review. Each round
+produced a rating that drove refinement:
+
+| Round | Rating | Key finding |
+|-------|--------|-------------|
+| 1 | "Embarrassingly temporary" | `done_event` bare pointer threaded through 6 public functions — parameter bloat, cross-layer coupling |
+| 2 | "Acceptable but rough" | Moving functions to private hides the bloat but doesn't fix internal coupling |
+| 3 | "Conditionally passes" | All intermediate functions must be private; single ownership for tmp buffer (unique_ptr); caller owns done_event (ctx only schedules) |
+| 4 | "Clean, approaching elegant" | Structure sound; remaining items are engineering hygiene (unique_ptr vs raw, find() vs bare [], cleanup audit) |
+
+## Ownership rules
+
+- `ctx->tmp`: owned by context, released automatically on destruction
+- `ctx->done_event`: caller-owned; context only calls `schedule()`, never `delete`
+- Context itself: heap-allocated in `sendCompletionSignal`, self-deletes in `complete()`
+- All early-exit paths (DMA read failure, address resolution failure, null event,
+  functional read path, callback not triggered) must reach `complete()` or
+  equivalent failure cleanup
+
+## Cross-references
+
+- `overview.md`: HSA layer and signal flow overview
+- `../../../cosim-gpu-rocm-stack/SKILL.md`: HSA signals from guest/driver side
+- `discovery-log.md` entry 6: interrupt VMID routing discovery that preceded this design work

--- a/.agents/skills/cosim-gpu-debug/references/gem5-model/overview.md
+++ b/.agents/skills/cosim-gpu-debug/references/gem5-model/overview.md
@@ -1,0 +1,109 @@
+# gem5 MI300X Model Reference
+
+Use this reference when `cosim-gpu-debug` evidence points at gem5 GPU behavior:
+PM4, SDMA, interrupts, HSA queues, VMID/PASID, translation, TLB/PWC, or cache
+maintenance.
+
+## Architecture
+
+```
+Guest ROCm driver
+  <-> QEMU MI300X cosim device or vfio-user-pci
+  <-> gem5 MI300X GPU model
+      AMDGPUDevice
+      PM4PacketProcessor
+      SDMAEngine
+      HSAPacketProcessor
+      GPUDynInst
+      Ruby memory system
+```
+
+## Key source files
+
+| Area | Files | Use |
+|------|-------|-----|
+| Device | `gem5/src/dev/amdgpu/amdgpu_device.cc/hh` | BARs, VMID allocation, PASID mapping, interrupts |
+| VM | `gem5/src/dev/amdgpu/amdgpu_vm.cc/hh` | GPU page tables, GART, translation, TLB/PWC invalidation |
+| PM4 | `gem5/src/dev/amdgpu/pm4_packet_processor.cc/hh` | MAP_PROCESS, RUN_LIST, INDIRECT_BUFFER, RELEASE_MEM, WRITE_DATA |
+| Interrupts | `gem5/src/dev/amdgpu/interrupt_handler.cc/hh` | CP_EOP and TRAP interrupt cookies |
+| SDMA | `gem5/src/dev/amdgpu/sdma_engine.cc/hh` | copy operations |
+| HSA | `gem5/src/dev/hsa/hsa_packet_processor.cc/hh` | AQL dispatch, barriers, signals |
+| Scheduler | `gem5/src/dev/hsa/hw_scheduler.cc/hh` | queue management and RUN_LIST |
+| Compute | `gem5/src/gpu-compute/gpu_command_processor.cc/hh` | kernel launch and kernarg handling |
+| TLB | `gem5/src/arch/amdgpu/vega/tlb.cc` | TLB and page-walk-cache behavior |
+| Ruby | `gem5/src/mem/ruby/**` | GPU cache hierarchy and maintenance callbacks |
+
+## PM4 command flow
+
+```
+Guest doorbell write
+  -> PM4PacketProcessor::processPkt()
+  -> MAP_PROCESS allocates VMID and binds PASID
+  -> RUN_LIST submits command buffers
+  -> INDIRECT_BUFFER follows command buffer chains
+  -> WRITE_DATA writes constants or signals
+  -> RELEASE_MEM flushes and writes completion signal
+```
+
+## Interrupt handling
+
+| Source | Purpose | VMID sensitivity |
+|--------|---------|------------------|
+| CP_EOP | command processor completion | VMID from running queue |
+| TRAP | exception or page fault | not VMID-sensitive in current model |
+
+`interrupt_handler.cc::prepareInterruptCookie()` sets PASID and VMID from the
+current context. Guest amdgpu uses the cookie to route interrupts to the owning
+process.
+
+## VMID and PASID
+
+- VMID selects the GPU page-table context. VMID 0 is reserved for kernel or
+  driver paths.
+- PASID identifies the process address space.
+- MAP_PROCESS binds PASID to a VMID.
+- `pasidFromVMID()` returns the mapped PASID or 0 when unknown.
+- Current testing is centered on one user VMID.
+
+For the full semantics, read `vmid-pasid-architecture.md`.
+
+## MAP_QUEUES VMID assertion
+
+When launch or driver initialization fails with QEMU `error_setv`, vfio-user
+abort, socket close, or a missing gem5 container, inspect:
+
+```bash
+grep -n 'assert.*vmid\|assert(queue_vmid)\|MAPQueues' \
+  gem5/src/dev/amdgpu/pm4_packet_processor.cc
+```
+
+If `assert(queue_vmid)` is present near MAP_QUEUES, read
+`vmid-assert-lesson.md` and `examples/vmid-assert-crash.md`. In this pattern,
+QEMU reports the socket failure after gem5 exits first.
+
+Accepted fallback:
+
+```cpp
+const uint16_t queue_vmid =
+    pkt->vmid ? pkt->vmid : gpuDevice->lastVMID();
+```
+
+## Translation and cache checkpoints
+
+- TLB and PWC invalidation are separate model responsibilities.
+- PWC entries are not tagged per VMID in the current model.
+- CP writes can bypass the same GL2 path used by CU scalar loads.
+- Kernarg correctness can require GL2 and SQC maintenance before shader
+  execution.
+
+Read `cache-coherence-checkpoints.md` and `discovery-log.md` when logs show
+translation, kernarg, SQC, GL2, PWC, or TLB symptoms.
+
+## Known limitations
+
+1. Single user VMID is the normal tested path.
+2. Power management is disabled through driver parameters.
+3. Device-side printf is unsupported and can hang.
+4. Some HSA packets may be fake-completed by the packet processor.
+5. Cherry-picking from `fix-hsa-signal-ih-completion-2` can introduce the
+   MAP_QUEUES VMID assertion.

--- a/.agents/skills/cosim-gpu-debug/references/gem5-model/vmid-assert-lesson.md
+++ b/.agents/skills/cosim-gpu-debug/references/gem5-model/vmid-assert-lesson.md
@@ -1,0 +1,133 @@
+# VMID Assertion in PM4 mapQueues
+
+## Cherry-Pick Gate — READ FIRST
+
+When cherry-picking ANY commit from `fix-hsa-signal-ih-completion-2`
+to another branch, `assert(queue_vmid)` WILL be introduced and WILL
+crash cosim during GPU init. Check immediately after cherry-pick:
+
+```bash
+grep -n 'assert.*vmid' src/dev/amdgpu/pm4_packet_processor.cc
+```
+
+If line 532 is `assert(queue_vmid);`, replace with:
+
+```cpp
+const uint16_t queue_vmid = pkt->vmid ? pkt->vmid : gpuDevice->lastVMID();
+```
+
+See ## Fix below for details.
+
+## Discovery
+
+June 2026, cosim launch crash investigation. Guest amdgpu driver loaded
+successfully but gem5 crashed during PM4 MAP_QUEUES packet processing
+with `assert(queue_vmid)` at `pm4_packet_processor.cc:532`.
+
+The assertion was introduced by commit `aa5d08d97773` on branch
+`fix-hsa-signal-ih-completion-2`, which threads VMID through the signal
+completion chain for multi-process HSA support.
+
+## Evidence
+
+### Crash chain
+
+```
+amdgpu driver sends MAP_QUEUES PM4 packet with vmid=0
+  → PM4PacketProcessor::mapQueues(pkt)
+    → const uint16_t queue_vmid = pkt->vmid;  // = 0
+    → assert(queue_vmid);                      // FAILS
+  → gem5 dies
+  → vfio-user socket closes
+  → QEMU vfio_user_recv_hdr sees ECONNRESET
+  → qio_channel_readv_full sets *errp
+  → error_setg_errno sets *errp again → assert(*errp == NULL) fails → SIGABRT
+```
+
+### Before the assertion (working code, commit `8680505b71`):
+
+```cpp
+// pm4_packet_processor.cc:mapQueues, before VMID threading:
+gpuDevice->mapDoorbellToVMID(pkt->doorbellOffset << 2,
+                             gpuDevice->lastVMID());
+```
+
+### After the assertion (broken, commit `aa5d08d97773`):
+
+```cpp
+// pm4_packet_processor.cc:532:
+const uint16_t queue_vmid = pkt->vmid;
+assert(queue_vmid);
+//
+gpuDevice->mapDoorbellToVMID(pkt->doorbellOffset << 2, queue_vmid);
+```
+
+### Branches affected
+
+| Branch | Commit | Has assert? | Status |
+|--------|--------|-------------|--------|
+| `fix-hsa-signal-only` | `8680505b71` | No | Works |
+| `fix-hsa-signal-ih-completion-2` | `aa5d08d97773` through `c45d23ac67` | Yes | Broken |
+| `fix-hsa-signal-only@{1}` (reflog) | `7d31539b26` (cherry-pick) | Yes | Was broken, reset to `8680505b71` |
+
+## First failing mechanism
+
+The amdgpu driver does not currently set the `vmid` field in MAP_QUEUES
+PM4 packets (driver uses `discovery=2`, single-process mode with
+`ip_block_mask=0x67`). The original code used `gpuDevice->lastVMID()` as
+a fallback when `pkt->vmid` was zero. The VMID threading changes removed
+this fallback and replaced it with an unconditional `assert(queue_vmid)`,
+which fires when `pkt->vmid == 0`.
+
+The commit message for `aa5d08d97773` acknowledges this:
+> "VMID multi-process support will be added in a follow-up."
+
+The assertion is premature — the driver-side VMID setup hasn't been
+implemented yet.
+
+## Fix
+
+Either:
+
+1. **Defensive fallback** (match original behavior):
+   ```cpp
+   const uint16_t queue_vmid = pkt->vmid ? pkt->vmid : gpuDevice->lastVMID();
+   ```
+
+2. **Deferred assert** — keep the assert but gate it behind a config
+   flag or multi-process mode check, so single-process (current) mode
+   doesn't trigger it.
+
+3. **Driver-side fix** — implement VMID setup in the amdgpu driver's
+   PM4 packet builder so MAP_QUEUES packets carry a valid VMID.
+   This is the long-term correct fix but requires driver changes.
+
+## Secondary effect: QEMU double-error assertion
+
+The gem5 crash masked a QEMU bug in `hw/vfio-user/proxy.c`:
+`vfio_user_recv_hdr` passes `errp` to `qio_channel_readv_full`, which
+sets `*errp` on failure, then `error_setg_errno` tries to set it again
+→ `assert(*errp == NULL)` fails.
+
+This is a defensive bug — the double-set is always wrong, but the path
+is only reached when gem5 closes the socket unexpectedly. The fix
+(pass `&local_err` and `error_propagate_prepend`) should be applied
+regardless.
+
+Upstream QEMU (`gitlab.com/qemu-project/qemu`, master) has the identical
+double-error pattern in `proxy.c:234-241`.
+
+## Verification
+
+- `fix-hsa-signal-only` / `fix/ip-discovery-vram` at `8680505b71`:
+  GPU init succeeds (`1/1 GPU(s) initialized`)
+- Same commit + cherry-picked VMID changes:
+  gem5 crash (`assert(queue_vmid)`)
+- QEMU proxy.c fix is independently verified but not required for
+  single-process mode with working gem5
+
+## Skill routing
+
+- `overview.md` PM4 section
+- `../qemu/error-setv-pattern.md` for the QEMU secondary failure chain
+- `cosim-gpu-rocm-stack` driver parameter reference (`discovery=2`, `ip_block_mask=0x67`)

--- a/.agents/skills/cosim-gpu-debug/references/gem5-model/vmid-pasid-architecture.md
+++ b/.agents/skills/cosim-gpu-debug/references/gem5-model/vmid-pasid-architecture.md
@@ -1,0 +1,141 @@
+# VMID and PASID Architecture
+
+Reference for VMID/PASID semantics beyond the basics covered in the main skill.
+Consolidated from review and debugging sessions on `fix-hsa-signal-ih-completion-2`
+and `fix-hsa-signal-only` (June 2026).
+
+## VMID field duality
+
+Every queue carries two VMID-derived fields with different sources, different
+uses, and the potential to diverge:
+
+| Field | Source | Set at | Used for |
+|-------|--------|--------|----------|
+| `q->vmid()` (`PM4Queue::_vmid`) | `captured_vmid` from `newQueue()` | `mapQueues` via `lastVMID()` or explicit `vmid` arg | Doorbell mapping, interrupt routing, HSA queue descriptors, checkpoint — **this is what gem5 routes on** |
+| `mqd->hqd_vmid` (`QueueDesc`) | MQD DMA read from `CP_HQD_VMID` register | MQD writeback after `MAP_QUEUES` | DPRINTF logging, checkpoint serialization — **not used for routing** |
+
+**Risk**: The two fields can diverge. KIQ/PQ set `hqd_vmid` via MMIO but
+`newQueue()` without an explicit vmid argument falls back to `lastVMID()`,
+potentially routing internal queue interrupts to a user process.
+
+`q->vmid()` is the authoritative routing field. When debugging, cross-check
+both fields and verify they agree for the queue under investigation.
+
+## Why `pkt->vmid == 0` in MAP_QUEUES is correct
+
+Cross-validated against Linux KFD driver source. The amdgpu driver hardcodes
+`PACKET3_MAP_QUEUES_VMID(0)` in the KIQ ring buffer:
+
+```c
+// Linux drivers/gpu/drm/amd/amdgpu/gfx_v9_0.c:961
+amdgpu_ring_write(kiq_ring,
+    PACKET3_MAP_QUEUES_VMID(0) |
+    ...);
+```
+
+VMID is not carried in the MAP_QUEUES packet. It is set in the MQD (Memory-mapped
+Queue Descriptor) and transferred via DMA:
+
+```c
+// Linux drivers/gpu/drm/amd/amdkfd/kfd_mqd_manager_v9.c:321
+m->cp_hqd_vmid = q->vmid;
+```
+
+The KFD driver allocates VMID per-process:
+
+```c
+// kfd_device_queue_manager.c
+static int allocate_vmid(..., struct qcm_process_device *qpd, ...) {
+    if (list_empty(&qpd->queues_list))
+        retval = allocate_vmid(dqm, qpd, q);
+    q->properties.vmid = qpd->vmid;  // all queues share the process VMID
+}
+```
+
+Therefore `lastVMID()` as a fallback in `newQueue()` was always a temporal
+coincidence — "the most recently allocated VMID" happens to be "my VMID" in
+single-process mode, but this is not a semantic derivation.
+
+## `lastVMID()` elimination
+
+The `lastVMID()` method (`amdgpu_device.hh`) was a crutch used in three places:
+
+| Call site | Original | Correct fix |
+|-----------|----------|-------------|
+| `newQueue()` (PM4) | `q->vmid(vmid ? vmid : gpuDevice->lastVMID())` | `q->vmid(vmid)` — KIQ/PQ explicitly pass VMID 0 |
+| `mapQueues()` (PM4) | `lastVMID()` for doorbell offset mapping | `captured_vmid` captured before async MQD DMA |
+| `releaseMemDone()` (PM4) | `lastVMID()` for signal write | `q->vmid()` — queue already owns its VMID |
+
+`captured_vmid` is the correct fix for `mapQueues`: capture the value at
+packet-decode time before the async MQD DMA callback fires, because another
+MAP_PROCESS could change `lastVMID()` between decode and callback.
+
+## PASID address space
+
+AMD IOMMU partitions the 16-bit PASID space:
+
+```
+0x0000 ─────────────── 0x7FFF ─────────────────────── 0xFFFF
+  ↑ System/GPU reserved    ↑ User process PASID
+  (GFX engine, SDMA,       (first user = 0x8000)
+   IH ring, VCN, etc.)
+```
+
+| Range | Purpose |
+|-------|---------|
+| `0x0000 – 0x7FFF` | System / GPU internal: hardware engines (GFX, SDMA, VCN), IH ring |
+| `0x8000 – 0xFFFF` | User processes: KFD allocates one PASID per ROCm process |
+
+In cosim single-process mode, `cookie->pasid = 0x8000` is the first user PASID
+and `cookie->vmId = 8` corresponds to `AMDGPU_FIRST_COMPUTE_VMID` (KFD allocates
+VMIDs in range 8–15 for MI300X).
+
+The constants are defined in `interrupt_handler.hh`:
+
+```cpp
+constexpr uint32_t AMDGPU_FIRST_USER_PASID  = 0x8000;
+constexpr uint32_t AMDGPU_FIRST_COMPUTE_VMID = 8;
+```
+
+## SDMA RLC per-queue VMID
+
+The original code hardcoded `cur_vmid = 1` in SDMA RLC processing. Real hardware
+writes the VMID to `sdmax_rlcx_rb_cntl.RB_VMID` from queue properties.
+
+Fix applied (`sdma_engine.hh/.cc`):
+- `SDMAQueue` gains a `_vmid` field with getter/setter
+- `registerRLCQueue` accepts a `uint16_t vmid` parameter and calls `queue.setVmid(vmid)` for both RLC0 and RLC1
+- `processRLC` reads `cur_vmid = queue.vmid()` instead of the hardcoded `1`
+
+## KIQ/PQ internal queue VMID routing
+
+KIQ (Kernel Interface Queue) and PQ (Privileged Queue) are internal queues
+that execute with VMID 0. `newQueue()` must receive an explicit `vmid = 0`
+for these queues; using `lastVMID()` routes their interrupts to whatever
+user process last called MAP_PROCESS.
+
+## Multi-VMID testing
+
+VMID is allocated per-process, not per-stream. Multiple HIP streams within one
+process share the same VMID. Multi-VMID requires multiple independent processes.
+
+rocm-examples has no multi-VMID test cases. A custom shell script that launches
+two HIP programs asynchronously is the minimal test:
+
+```bash
+./hip_program_a &
+PID_A=$!
+./hip_program_b &
+PID_B=$!
+wait $PID_A $PID_B
+```
+
+This is an open gap — multi-VMID paths in the model are not currently exercised
+by automated tests.
+
+## Cross-references
+
+- `discovery-log.md` entry 6: interrupt VMID routing for multi-operation programs
+- `vmid-assert-lesson.md`: `assert(queue_vmid)` crash chain and QEMU secondary failure
+- `cache-coherence-checkpoints.md`: source-level checkpoints for TLB/PWC/cache
+- `../../../cosim-gpu-rocm-stack/SKILL.md`: HSA signals and KFD ioctls

--- a/.agents/skills/cosim-gpu-debug/references/qemu/error-setv-pattern.md
+++ b/.agents/skills/cosim-gpu-debug/references/qemu/error-setv-pattern.md
@@ -1,0 +1,116 @@
+# QEMU error_setv Double-Set Pattern
+
+Reference for diagnosing and fixing the `error_setv` assertion failure in QEMU.
+Discovered during cosim vfio-user launch debugging (June 2026).
+
+## Mechanism
+
+QEMU's error reporting convention uses `Error **errp` — a pointer to an
+error pointer. The invariant: `*errp` must be `NULL` when a new error is set.
+
+```c
+// util/error.c:51-62
+static void error_setv(Error **errp, ...) {
+    if (errp == NULL) {          // L59: NULL → harmless, return immediately
+        return;
+    }
+    assert(*errp == NULL);       // L62: *errp already set → SIGABRT
+}
+```
+
+Key behaviors:
+- `errp == NULL`: callee does not want error detail → `error_setv` returns early (no crash)
+- `errp != NULL && *errp == NULL`: normal path — first error is set
+- `errp != NULL && *errp != NULL`: **assertion fires** — a second error is being set on a dirty `*errp`
+
+## The anti-pattern
+
+Passing the same `Error **errp` to two functions that can both set errors:
+
+```c
+// ANTI-PATTERN (proxy.c:234-241, also present in upstream QEMU master):
+ret = qio_channel_readv_full(proxy->ioc, &iov, 1, fdp, numfdp, 0,
+                             errp);   // ← this may set *errp on failure (ECONNRESET)
+if (ret < 0) {
+    error_setg_errno(errp, errno, "failed to read header");
+    // ↑ tries to set *errp again → assert(*errp == NULL) fails → SIGABRT
+}
+```
+
+## The fix pattern
+
+Use a local `Error *` to decouple the two error-setting calls:
+
+```c
+// FIX:
+Error *local_err = NULL;
+ret = qio_channel_readv_full(proxy->ioc, &iov, 1, fdp, numfdp, 0,
+                             &local_err);  // isolate the inner error
+if (ret < 0) {
+    error_propagate_prepend(errp, local_err, "failed to read header: ");
+    // local_err is consumed; *errp is only set once
+}
+```
+
+`error_propagate_prepend` transfers ownership of `local_err` to `*errp`
+(with a prefix message), so `*errp` is set exactly once.
+
+## Identifying the pattern
+
+Search QEMU source for any function call that passes `errp` as argument
+followed by another error-set call on the same `errp`:
+
+```bash
+# Find potential double-set sites in QEMU
+search pattern="error_set[gv]_errno\(errp" paths=["qemu/"]
+# Cross-check: does the immediately preceding call also receive errp?
+```
+
+Additional risk: `error_report_err` + `error_free` is safe (it reads and clears
+`*errp`), but `error_report_err` alone leaves `*errp` set → next `error_setv`
+crashes if it receives the same `errp`.
+
+## Crash chain: gem5 → QEMU secondary failure
+
+The common trigger in cosim: gem5 crashes → socket closes → QEMU sees
+ECONNRESET → the double-set path is reached.
+
+```
+gem5 assert/crash → socket disconnect
+  → QEMU vfio_user_recv_hdr sees ECONNRESET
+  → qio_channel_readv_full sets *errp (ECONNRESET)
+  → error_setg_errno tries to set *errp again → SIGABRT
+```
+
+**The QEMU double-set is a defensive bug**: it should never happen in normal
+operation, but it should also never crash when it does happen. The gem5 crash
+is the first failing component; the QEMU crash is a secondary effect that masks
+it.
+
+## GDB debugging
+
+When the crash is inside QEMU, use a conditional breakpoint to isolate the
+real trigger (avoid stopping on harmless `errp == NULL` paths like SGX init):
+
+```gdb
+# Only break when the assertion would actually fire
+break error.c:62 if *errp != NULL
+
+# Or from command line:
+gdb -q -batch \
+  -ex 'break error.c:62 if *errp != NULL' \
+  -ex run \
+  -ex 'bt full' \
+  --args qemu/build/qemu-system-x86_64 [args...]
+```
+
+## Upstream status
+
+This bug exists in upstream QEMU (`gitlab.com/qemu-project/qemu`, master)
+at `hw/vfio-user/proxy.c:234-241`. The same fix applies.
+
+## Cross-references
+
+- `qemu-first-failure.md`: QEMU-first failure checks
+- `../gem5-model/vmid-assert-lesson.md`: the specific instance of this pattern in cosim (gem5 `assert(queue_vmid)` → QEMU double-error crash)
+- `../analysis/debug-analysis.md`: gem5 vs QEMU first-failure comparison

--- a/.agents/skills/cosim-gpu-debug/references/qemu/examples/proxy-double-error.md
+++ b/.agents/skills/cosim-gpu-debug/references/qemu/examples/proxy-double-error.md
@@ -1,0 +1,53 @@
+# QEMU Proxy Double-Error Crash (June 2026)
+
+`error_setv` assertion failure in `hw/vfio-user/proxy.c` during cosim launch.
+This was a secondary effect of gem5 crashing — QEMU's double-error-set pattern
+converted a socket disconnect into a SIGABRT instead of a clean error report.
+
+## When you'll hit this again
+
+- QEMU crashes with `error_setv: Assertion '*errp == NULL' failed`
+- gem5 container exits unexpectedly during guest driver init
+- The first failing component is on the gem5 side; QEMU is a secondary reporter
+
+## First failing mechanism
+
+```c
+// proxy.c:234 — anti-pattern
+ret = qio_channel_readv_full(proxy->ioc, &iov, 1, fdp, numfdp, 0, errp);
+// ↑ already set *errp on ECONNRESET
+if (ret < 0) {
+    error_setg_errno(errp, errno, "failed to read header"); // double-set → SIGABRT
+}
+```
+
+## Fix pattern
+
+```c
+Error *local_err = NULL;
+ret = qio_channel_readv_full(proxy->ioc, &iov, 1, fdp, numfdp, 0, &local_err);
+if (ret < 0) {
+    error_propagate_prepend(errp, local_err, "failed to read header: ");
+}
+```
+
+## Debugging method
+
+GDB conditional breakpoint to filter out harmless `errp == NULL` paths (SGX init):
+```
+break error.c:62 if *errp != NULL
+```
+
+## Upstream status
+
+Same bug exists in upstream QEMU master (`gitlab.com/qemu-project/qemu`).
+
+## Artifacts
+
+- `artifacts/pr4-qemu-error-setv-debug/` — full GDB debugging session
+- Session `~/.omp/agent/sessions/-cosim-gpu/2026-06-21T12-38-21-819Z*.jsonl` — investigation dialogue
+
+## Cross-references
+
+- `../error-setv-pattern.md` — error_setv mechanism and fix
+- `../../gem5-model/examples/vmid-assert-crash.md` — the gem5-side cause

--- a/.agents/skills/cosim-gpu-debug/references/qemu/qemu-first-failure.md
+++ b/.agents/skills/cosim-gpu-debug/references/qemu/qemu-first-failure.md
@@ -1,0 +1,42 @@
+# QEMU First-Failure Reference
+
+Use this reference only when QEMU itself is likely the first failing component:
+QEMU assertion, `error_setv` misuse, vfio-user protocol error, region access
+failure, QEMU trace-only symptom, or a QEMU process exit while gem5 remains
+alive and has no fatal event.
+
+## Component check
+
+Before calling a failure QEMU-first, compare:
+
+- last gem5 log line and container status
+- QEMU stderr and backtrace
+- guest console progress marker
+- socket close timing
+- vfio-user trace events
+
+If gem5 ends with `fatal`, `panic`, assertion, or container exit before QEMU
+aborts, return to `cosim-gpu-debug` and treat QEMU as a secondary reporter.
+
+## Evidence to collect
+
+- `qemu-stderr.log`
+- `qemu.log`
+- QEMU trace file with focused vfio-user or MI300X events
+- gdb backtrace showing the caller of `error_setv`, `abort`, or the assertion
+- matching QEMU source line
+
+Use `scripts/cosim_gdb_qemu.sh <run-id>` only as a debugger launcher. It starts
+a tmux-hosted GDB session; it does not produce evidence by itself.
+
+## Trace use
+
+Write needed trace events to the active artifact directory and pass them through
+the launcher:
+
+```bash
+--qemu-trace 'events=artifacts/<task>/scratch/qemu-trace-events.txt,file=artifacts/<task>/logs/qemu-trace.log'
+```
+
+Keep alternate binaries and wrappers explicitly labeled. Standard test runs
+should use the normal provenance path.

--- a/.agents/skills/cosim-gpu-disk-image-edit/SKILL.md
+++ b/.agents/skills/cosim-gpu-disk-image-edit/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: cosim-gpu-disk-image-edit
+description: Use when the guest disk image needs modification without a full rebuild. Mount with guestmount, add files, systemd services, kernel module config.
+---
+
+# Cosim Disk Image Edit
+
+Modify the cosim guest disk image without rebuilding.
+
+## Prerequisites
+
+- QEMU must NOT be running (disk image cannot be mounted while in use)
+- `guestmount` must be available (`libguestfs-tools` package)
+
+```bash
+pgrep -af 'qemu-system-x86_64|cosim_launch.sh|run_cosim_tests.sh' && echo "STOP COSIM FIRST" || echo "OK"
+find /tmp -maxdepth 1 -type d -name '*qemu-cosim*.session' -print
+which guestmount || echo "Install: apt install libguestfs-tools"
+```
+
+## Disk image location
+
+```
+gem5-resources/src/x86-ubuntu-gpu-ml/disk-image/x86-ubuntu-rocm70
+```
+
+Format: raw, GPT, partition 1 is the root filesystem.
+
+## Mount
+
+```bash
+DISK="./gem5-resources/src/x86-ubuntu-gpu-ml/disk-image/x86-ubuntu-rocm70"
+MOUNTPOINT="/tmp/cosim-disk"
+mkdir -p "$MOUNTPOINT"
+guestmount -a "$DISK" -m /dev/sda1 --rw "$MOUNTPOINT"
+```
+
+## Edit scope
+
+Supported edit classes:
+
+- Add or replace files under the guest filesystem.
+- Add or update systemd units and matching enablement symlinks.
+- Add or update kernel module configuration under `/etc/modprobe.d/`.
+- Install ROCm runtime debug components through repository scripts when the task is runtime debugging.
+- Inspect disk layout with `fdisk -l "$DISK"` if `guestmount` cannot find `/dev/sda1`.
+
+Keep the concrete file contents in the task artifact or source patch. Do not embed large service templates or generated scripts in the skill itself.
+
+## Unmount
+
+Always unmount before starting QEMU:
+
+```bash
+guestunmount "$MOUNTPOINT"
+sleep 2
+ls "$MOUNTPOINT" 2>/dev/null && echo "Still mounted!" || echo "OK"
+```
+
+## Notes
+
+- `guestmount` uses FUSE — no sudo needed
+- Changes write directly to raw image file
+- Back up the disk image before risky changes (55 GB, consider snapshots)

--- a/.agents/skills/cosim-gpu-flow-plan/SKILL.md
+++ b/.agents/skills/cosim-gpu-flow-plan/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: cosim-gpu-flow-plan
+description: Use as the first step for non-trivial cosim testing, debugging, review, or iterative implementation tasks. Do not use for ordinary repository maintenance such as commit splitting, submodule pointer updates, author config, or documentation-only cleanup.
+---
+
+# Cosim Flow Plan
+
+Use as the first step for non-trivial cosim tasks: testing, bug localization,
+code review, or iterative implementation. It creates a standardized task
+workspace and hands off to the domain skill.
+
+Do not use this skill for ordinary repository maintenance: commit splitting,
+submodule pointer updates, history rewriting requested only for commit hygiene,
+author configuration, `.gitignore` changes, documentation-only cleanup, or
+skill-directory refactoring that does not require cosim execution evidence.
+
+## Hard policy
+
+- For cosim test, debug, review, and RLCR tasks, do not modify source files
+  before the plan is written and the evidence ledger has confirmed the target.
+- Review tasks require explicit human confirmation of the target before any
+  reviewer delegation, test execution, or source edit. The confirmed target must
+  name the reviewed change, base reference, file or subsystem scope, allowed
+  source changes, required evidence, and stopping rule if one is supplied.
+- All agent-created artifacts stay under `artifacts/<task-slug>/`.
+- Do not add AI roles such as Codex or Claude to contribution trailers. When a commit needs `Signed-off-by`, use the human author identity from `git config user.name` and `git config user.email`.
+- Formatting must be diff-scoped. Whole-file or project-wide formatter output
+  mixed with behavior changes is a hard failure unless the confirmed task is
+  explicitly formatting-only. Prefer `clang-format-diff`, gem5's modified-range
+  style tools, or an equivalent patch-range formatter; otherwise format only
+  the changed hunk and its immediate context. Before commit, compare normal
+  diff stats with whitespace-ignored diff stats and remove unrelated formatter
+  churn.
+- Optimization edits must be based on current `HEAD`. A historical commit may
+  be the reviewed change, but source changes are applied to checked-out `HEAD`
+  after recording `git rev-parse HEAD` and whether the reviewed commit is an
+  ancestor of `HEAD`. If later commits already changed the same area, classify
+  findings against current `HEAD` before editing.
+
+## Workspace
+
+```text
+artifacts/<task-slug>/
+├── plan.md
+├── evidence.md
+├── commands.md
+├── patch/
+│   ├── base-commits.txt       # repo path, branch, hash, and commit message
+│   └── binary-provenance.txt
+├── logs/
+├── state/
+├── tests/                 # per-run test artifacts
+├── reviews/               # independent review briefs and outputs
+├── matrix.tsv          # test tasks only
+├── review-findings.md   # review tasks only
+├── rlcr/                 # iterative implementation/debug/validation tasks only
+└── scratch/
+```
+
+## Task types
+
+Choose one template based on the task.
+
+For authorization boundaries, goal status, artifact relocation, or checkpoint
+continuation, read `references/policy-and-checkpoint.md`.
+
+### Test (`--type test`)
+
+Goal: execute programs against cosim and classify outcomes.
+
+Template fields:
+- program list, source repo/path, build target
+- interrupt mode (`HSA_ENABLE_INTERRUPT=0` or `1`)
+- execution mode (`single`, `repeated`, `multi`)
+- timeout strategy (two-phase: probe → precise)
+- expected baseline (reference working case)
+
+Output: `matrix.tsv` with per-program outcome rows.
+
+Hand off to: `cosim-gpu-test`.
+
+### Debug (`--type bug`)
+
+Goal: prepare a workspace for log-driven debug investigation.
+
+Template fields:
+- initial symptom and outcome class
+- failing program or workload
+- expected nearest working baseline, if known
+- evidence paths already available
+- allowed investigation scope
+
+Hand off to: `cosim-gpu-debug`.
+
+### Review (`--type review`)
+
+Goal: review local changes before pushing through the independent reviewer
+workflow.
+
+Template fields:
+- commit or PR reference
+- current `HEAD` used for any optimization edits
+- whether the reviewed commit is an ancestor of `HEAD`
+- review scope (subsystem, files)
+- explicit user-confirmed review target
+- requested round count, if specified
+- stopping rule, if specified
+- required evidence gates
+- allowed automated tests and fixed environment rows
+
+Do not classify review tasks into quick/full modes. `cosim-gpu-review` owns the
+independent review workflow; the user controls only the round count and stop
+condition when they specify them.
+
+Hand off to: `cosim-gpu-review`.
+
+### RLCR (`--type rlcr`)
+
+Goal: run iterative implementation, debugging, or validation rounds.
+
+Template fields:
+- round objective and acceptance criteria
+- owning domain or operational skill
+- verification gates
+- independent review path
+- stop condition
+
+Hand off to: `cosim-gpu-rlcr-loop`.
+
+## Plan Template
+
+Read `references/plan-template.md` when creating `plan.md`.
+
+## Composition
+
+After `cosim-gpu-flow-plan`, invoke the domain skill:
+- Test task → `cosim-gpu-test`
+- Bug task → `cosim-gpu-debug`
+- Review task → `cosim-gpu-review`
+- RLCR task → `cosim-gpu-rlcr-loop`
+
+Domain skills read `plan.md` from the active workspace. Use `cosim-gpu-build` for
+all build and provenance decisions.

--- a/.agents/skills/cosim-gpu-flow-plan/references/plan-template.md
+++ b/.agents/skills/cosim-gpu-flow-plan/references/plan-template.md
@@ -1,0 +1,77 @@
+# Plan Template
+
+Read this when creating `artifacts/<task-slug>/plan.md`.
+
+```markdown
+# <Task Title>
+
+## Goal
+
+## Policy
+- All artifacts under artifacts/<task-slug>/
+- No source edits before evidence confirms target.
+- Formatting must be diff-scoped. Whole-file formatter churn mixed with
+  behavior changes fails acceptance unless this is a formatting-only task.
+- Review tasks require explicit human confirmation of reviewed change, base
+  reference, scope, allowed source changes, evidence gates, and stopping rule
+  before reviewer delegation, test execution, or source edits.
+- Optimization edits target current `HEAD`; historical commits are review
+  inputs unless the user explicitly requests history rewriting.
+- Commit provenance must include hash and commit message for every repository
+  whose state affects evidence.
+
+## Task type
+<!-- test | bug | review | rlcr -->
+
+## Scope
+### In scope
+### Out of scope
+### Allowed source changes
+
+## Confirmed Target
+<!-- required for review tasks before execution -->
+- Reviewed change:
+- Base reference:
+- Optimization base:
+- Reviewed change ancestry:
+- File or subsystem scope:
+- Allowed automated tests:
+- Fixed environment rows:
+- Stopping rule:
+
+## Build and provenance gate
+- Use the gate defined by `cosim-gpu-build`.
+- Record base commits in `patch/base-commits.txt` with repository path, branch
+  or detached state, `HEAD` hash, and commit subject.
+- Record formatter-scope evidence when style churn is part of the risk.
+
+## Acceptance Criteria
+- AC-1:
+  - Evidence:
+
+## Evidence Ledger
+| Step | Action | Artifact | Result |
+
+## Open Questions
+
+## Discarded Hypotheses
+| Hypothesis | Why discarded | Evidence |
+|---|---|---|
+
+## Decision Log
+```
+
+## Creation Steps
+
+1. Create workspace:
+   `mkdir -p artifacts/<task-slug>/{patch,logs,state,scratch,rlcr,reviews,tests}`.
+2. Write `plan.md` using the task type.
+3. Use `cosim-gpu-build` before accepting build or test evidence.
+4. Write `patch/base-commits.txt` for top-level cosim plus relevant nested
+   repositories such as gem5 and QEMU.
+5. State whether final evidence must come from the intended test path or older
+   rows are comparison samples.
+6. For review or RLCR optimization of a historical commit, record current
+   `HEAD`, ancestry relation, and that edits target current `HEAD`.
+7. Add a checkpoint note for multi-turn tasks.
+8. Hand off to the next domain skill.

--- a/.agents/skills/cosim-gpu-flow-plan/references/policy-and-checkpoint.md
+++ b/.agents/skills/cosim-gpu-flow-plan/references/policy-and-checkpoint.md
@@ -1,0 +1,92 @@
+# Policy And Checkpoint
+
+Read this when the task spans multiple turns, has an active user goal, or needs
+automation after a confirmed target.
+
+## Automation Boundary
+
+The planning gate is where human control belongs. If the plan has a complete
+and confirmed target, later fixed execution steps may run without repeated
+approval when they are read-only or use repository-owned scripts with an
+accepted manifest.
+
+Explicit broad approval for the current target covers standard builds, fixed
+manifest rows, same-target reruns, local log reads, and diagnostic-only
+instrumentation inside the accepted scope. It does not cover target changes,
+new binaries, cold rebuilds, disk-image edits, destructive cleanup, external
+services, or public artifacts.
+
+Allowed automated steps after target confirmation:
+
+- standard incremental builds required by `cosim-gpu-build`
+- standard preflight cleanup required by launch or test skills
+- fixed test rows from a complete run manifest
+- fixed environment matrix rows named by the plan
+- post-fix reruns inside the same scope
+- local log, diff, and artifact reads
+- diagnostic-only source instrumentation guarded by debug flags when the active
+  debug plan names the file scope
+- checkpoint reconstruction from an active artifact workspace
+- rerun of an incomplete manifest row when no matching live process remains
+- summary updates that copy already-proven verdict, matrix, and provenance
+  facts into active evidence files
+
+Ask before actions that change target, widen review scope, switch to a
+nonstandard binary, request a full or cold rebuild, edit a disk image, delete
+files outside repository cleanup scripts, access external services, or create
+public artifacts.
+
+## Goal Scope
+
+- Keep broad objective and phase objective distinct.
+- Before marking a goal complete, name acceptance criteria and artifact paths.
+- If work changed from exploration to a diagnostic stage, record whether that
+  stage replaces the active goal or only advances it.
+- Do not mark a broad optimization goal complete merely because a bottleneck
+  class was found.
+- When asked about goal status, answer with phase status and remaining parent
+  objective, if any.
+
+## Checkpoint Execution
+
+Use this after interruption, context compaction, or a user message such as
+`continue`.
+
+Reconstruct state from the active artifact workspace before asking whether to
+proceed:
+
+- `plan.md`
+- `commands.md`
+- `matrix.tsv`
+- run manifests
+- build provenance
+- live process state
+
+Continue only steps authorized by the task boundary:
+
+- Review tasks: Confirmed Target and required evidence gates.
+- Test tasks: accepted run manifests and fixed environment rows.
+- RLCR tasks: frozen acceptance criteria and `rlcr/goal-tracker.md`.
+- Bug/debug tasks: plan scope and evidence ledger.
+
+When executing from a checkpoint:
+
+- If a command lacks a verdict or review artifact, classify it as incomplete.
+- If no live process remains and the row is still accepted, rerun through the
+  standard skill path.
+- If a live process remains, observe or clean it only through the relevant
+  repository-owned skill.
+- If a long-running test is alive, wait for runner artifacts or collect a
+  bounded live-state sample only when the debug plan asks for it.
+- If runner artifacts have verdict, matrix, and binary provenance, treat them
+  as authoritative over chat observations.
+- Ask only if the remaining step changes target, scope, binary, environment
+  values, workload set, or rebuild policy.
+
+## Artifact Relocation
+
+For large artifact relocation to external storage, keep copy, verification,
+link replacement, and old-copy deletion as separate steps. Never remove the
+original directory until copied target counts or size match, a dry-run sync
+reports no remaining changes, and ordinary repository paths work through the
+new symlink.

--- a/.agents/skills/cosim-gpu-guest/SKILL.md
+++ b/.agents/skills/cosim-gpu-guest/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: cosim-gpu-guest
+description: Use when you need to send commands to a running cosim guest. Console pipe interaction, 9p share mount, GPU status check, manual driver load.
+---
+
+# Cosim Guest
+
+Interact with the cosim guest Linux through the detached runner session created
+by `scripts/run_cosim_tests.sh --hang-env`.
+
+## Prerequisites
+
+The runner prints the active console log and control pipe when it leaves a hang
+debug environment alive:
+
+```text
+Console log: /path/to/qemu.log
+Console pipe: /tmp/<session-name>-<run-id>.session/console.in
+```
+
+If those lines are unavailable, derive the paths from the run id and session
+name used for the `--hang-env` command:
+
+```bash
+SESSION_NAME=qemu-cosim-tests
+RUN_ID=<run-id>
+CONSOLE_PIPE="/tmp/${SESSION_NAME}-${RUN_ID}.session/console.in"
+CONSOLE_LOG="/tmp/${SESSION_NAME}-${RUN_ID}.log"
+docker ps --filter name=gem5-cosim --format '{{.Names}}: {{.Status}}'
+test -p "$CONSOLE_PIPE"
+test -f "$CONSOLE_LOG"
+```
+
+## Sending Commands
+
+```bash
+printf '%s\n' '<command>' > "$CONSOLE_PIPE"
+printf '\003' > "$CONSOLE_PIPE"   # Ctrl-C
+tail -n 80 "$CONSOLE_LOG"
+```
+
+Wait pattern:
+```bash
+baseline=$(wc -l < "$CONSOLE_LOG")
+printf '%s\n' '<command>' > "$CONSOLE_PIPE"
+while true; do
+    current=$(wc -l < "$CONSOLE_LOG")
+    if [[ "$current" -gt "$((baseline + 3))" ]]; then
+        tail -20 "$CONSOLE_LOG"
+        break
+    fi
+    sleep 2
+done
+```
+
+## Common operations
+
+### Mount 9p share
+
+```bash
+printf '%s\n' 'mount -t 9p -o trans=virtio,version=9p2000.L cosim_share /mnt' > "$CONSOLE_PIPE"
+```
+
+After mounting, paths under `/mnt` must resolve inside the shared tree. Host
+symlinks that point outside the shared repository will appear in the guest but
+may resolve to an unmounted guest path. If a script or artifact is missing
+through such a symlink, classify it as a guest bridge path issue and rerun with
+a guest-visible path before using the result as model evidence.
+
+Do not assume any particular host storage layout for artifacts. One developer
+may keep artifacts as a real directory, another may point it at a larger disk,
+and a CI worker may use a temporary workspace. Runner scripts that execute in
+the guest should therefore use a configurable guest-visible bridge path inside
+the shared tree, while final logs, matrices, verdicts, and provenance are still
+archived under the requested artifact directory. The transient bridge directory
+is not evidence by itself; preserve its script and output under the row artifact
+before cleanup.
+
+### Build and run tests
+
+```bash
+# Build tests from 9p share
+printf '%s\n' 'cd /mnt/tests && make -j1' > "$CONSOLE_PIPE"
+
+# Run a ROCm device program with the same privilege level as the test runner.
+printf '%s\n' "printf '%s\n' \"\${COSIM_GUEST_SUDO_PASSWORD:?set COSIM_GUEST_SUDO_PASSWORD}\" | sudo -S bash -lc 'cd /mnt/tests && ./build/vector_add'" > "$CONSOLE_PIPE"
+```
+
+Use this privilege pattern for programs that open `/dev/kfd` or
+`/dev/dri/renderD*`. A plain `gem5` user launch is an invalid device-debug
+setup because it can enumerate no GPU device.
+
+### Check GPU status
+
+```bash
+printf '%s\n' 'rocm-smi' > "$CONSOLE_PIPE"
+printf '%s\n' 'rocminfo 2>/dev/null | head -40' > "$CONSOLE_PIPE"
+printf '%s\n' 'dmesg | grep -i amdgpu | tail -10' > "$CONSOLE_PIPE"
+```
+
+### Manual driver load
+
+```bash
+printf '%s\n' 'dd if=/root/roms/mi300.rom of=/dev/mem bs=1k seek=768 count=128 && rm -f /run/modprobe.d/*blacklist* && modprobe amdgpu ip_block_mask=0x67 ppfeaturemask=0 dpm=0 audio=0 ras_enable=0 discovery=2' > "$CONSOLE_PIPE"
+```
+
+### Shutdown
+
+```bash
+printf '%s\n' "printf '%s\n' \"\${COSIM_GUEST_SUDO_PASSWORD:?set COSIM_GUEST_SUDO_PASSWORD}\" | sudo -S poweroff" > "$CONSOLE_PIPE"
+```
+
+Use privileged shutdown after hang-debug evidence is saved. This matches the
+privilege level used for ROCm device programs and avoids leaving a live guest
+waiting for manual poweroff. If the guest no longer accepts console input,
+record that fact and use the host cleanup script.
+
+## Integration
+
+- Use `cosim-gpu-test` for automated test execution
+- Use `cosim-gpu-debug` for two-sided inspection
+- For manual debugging sessions, send commands directly as shown above

--- a/.agents/skills/cosim-gpu-info-gathering/SKILL.md
+++ b/.agents/skills/cosim-gpu-info-gathering/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: cosim-gpu-info-gathering
+description: Use when collecting, summarizing, auditing, or comparing cosim evidence from artifact directories, large logs, matrices, verdict files, build provenance, or prior conversation records; also use when reducing raw log reads or checking whether existing artifacts lose information. Enforces full raw evidence preservation, bounded reads, source attribution, compact tables, raw-read plans, coverage self-reporting, and unknown-event preservation before analysis.
+---
+
+# Cosim Information Gathering
+
+Use this skill before broad log review, prior conversation scans, or cross-artifact
+summaries. Its job is to build a compact, attributed evidence map that other
+skills can reason from.
+
+## Source Order
+
+Prefer archived artifacts over chat memory and live output:
+
+1. Matrix files: `matrix.final.tsv`, `matrix.tsv`
+2. Per-row verdicts: `tests/*/verdict.json`
+3. Provenance: `patch/binary-provenance.txt`
+4. Logs: `logs/gem5.log`, `logs/qemu.log`, `logs/guest/**/*.log`
+5. Runner metadata and guest scripts
+6. Prior conversation records, only when the task is explicitly about process
+   history or skill behavior
+
+Every extracted fact must retain source file, line number when available, and
+the table or rule that produced it.
+
+## Evidence Preservation
+
+Preserve raw evidence before optimizing the conversation. Token savings belong
+to what the agent reads and quotes, not to what a diagnostic run records.
+
+For each test row, keep complete archived logs when the runner can provide
+them:
+
+- `logs/gem5.log`
+- `logs/qemu.log`
+- `logs/guest/**/*.log`
+- exact command, environment, verdict, matrix row, build hash, and source
+  fingerprint
+
+Compact summaries are indexes over raw evidence. They must not be the only copy
+of a diagnostic observation unless the observation was never available in raw
+form.
+
+## Run Isolation
+
+Keep each evidence intake tied to one explicit source set. Do not mix session
+records, live command output, and artifact summaries from different task turns
+unless the output names each source and range.
+
+For session extracts, record the exact session path, start line, end line,
+whether tool output was included, and the text limit used. For artifact audits,
+record the artifact root and generated table directory. A later review should
+be able to tell whether two rows came from the same evidence intake or from
+different test rounds.
+
+## Bounded Reads
+
+Do not scan home directories, token stores, or unrelated session trees. When a
+conversation record is required, identify the exact session file first and parse
+only user, assistant, command, and command-output summaries needed for the task.
+Use `.agents/skills/cosim-gpu-info-gathering/scripts/codex_session_extract.py`
+when available. Do not use `head`, plain `rg`, or broad filesystem search on
+JSONL session records.
+
+For session review, keep source file, line range, record kind, and bounded text
+visible. Treat developer, token-count, metadata, tool-schema, and raw
+tool-output records as out of scope unless the task explicitly targets them.
+Tool outputs must be redacted when included.
+
+For logs, start with compact tables:
+
+Generate these tables with `python3 scripts/cosim_artifact_audit.py --root
+<artifact-root> --out <artifact-root-or-task>/audit` when the artifact layout is
+compatible. If the script cannot cover the layout, record that fact and produce
+the same table contract manually.
+
+- `evidence_index.tsv`: available files, roles, and sizes
+- `raw_evidence_contract.tsv`: required raw evidence roles and missing files
+- `row_status.tsv`: artifact completeness and missing fields
+- `verdicts.tsv`: outcome and verdict source
+- `provenance.tsv`: gem5 source and binary identity
+- `log_availability.tsv`: gem5, QEMU, and guest log presence
+- `filter_coverage.tsv`: diagnostic filters, observed extrema, and uncovered counts
+- `signals.tsv`: known high-value lines with source and line number
+- `candidate_events.tsv`: low-confidence structural log candidates
+- `review_queue.tsv`: rows that need agent interpretation
+- `raw_read_plan.tsv`: minimal raw files and line windows to inspect
+
+Open raw logs only after these tables identify a row, source file, and line
+range.
+
+When a command writes an artifact directory, inspect generated files only after
+the command has finished. Do not launch read commands in parallel with the
+writer for validation evidence.
+
+## Accuracy Rules
+
+Separate deterministic extraction from interpretation. Scripts may decide file
+presence, manifest completeness, verdict fields, exact environment values,
+source line numbers, and known signal matches. Agents decide ownership,
+mechanism, experiment priority, and source-edit readiness.
+
+Never replace raw evidence with a summary. A summary is valid only when the raw
+source path remains available and the extracted row can be regenerated.
+
+When a top-level `evidence.md`, aggregate table, or hand-written summary
+conflicts with a per-row artifact, prefer the per-row files from the same
+artifact directory: `verdict.json`, `matrix.tsv`, `patch/source-snapshot.txt`,
+`patch/binary-provenance.txt`, and logs. Record the summary as stale or
+inconsistent. Do not classify the source change as unproven when row-local
+source snapshot, binary provenance, and verdict agree.
+
+Filtered diagnostics must self-report coverage. Record the filter expression,
+covered object range, final observed object range, and uncovered object count.
+If a final waiting object lies outside the filter range, mark the row
+`coverage_insufficient` and rerun or reprocess with a wider range before using
+the absence of events as evidence.
+
+Rows that did not use diagnostic filters may report `not_applicable` in
+`filter_coverage.tsv`. Do not treat missing filter coverage as a defect unless
+the manifest, debug flags, or generated artifacts show that filtering was used.
+
+## Unknown Events
+
+Unknown evidence must remain visible. If a non-PASS row has no known signal,
+mark it as `nonpass_unclassified`. If a log line looks relevant but does not
+match a known rule, record it as a candidate with low confidence rather than
+forcing it into an old category.
+
+Candidate extraction should stay structural: use log tails, existing signal
+neighborhoods, verdict sources, and exit-code neighborhoods. Do not add broad
+keyword sets merely to make more rows look classified.
+
+## Artifact Capacity
+
+Use this when the task asks about `artifacts` size, cleanup, or relocation.
+
+- Start read-only: `du -sh artifacts`, `df -h .`, `df -h <candidate-target>`
+  when a relocation target is named, and largest immediate children with
+  `du -sh artifacts/* | sort -h`.
+- If `artifacts` is a directory symlink, plain `find artifacts` inspects the
+  link itself. Use `artifacts/` or an explicit symlink-following mode when
+  counting target contents.
+- For relocation to external storage, keep phases separate: copy to a new
+  target, verify size and entry counts, run an `rsync --dry-run` or equivalent
+  no-difference check, rename the original directory, create the project-local
+  symlink, verify normal reads through the symlink, then remove the old copy.
+- Do not delete evidence solely from directory names. Identify largest files
+  and whether they are reproducible worktree/build products, logs, or unique
+  verdict/provenance records.
+- After cleanup or relocation, report both `artifacts` logical size and root
+  filesystem free space. A deleted path may not free space if another large
+  artifact appeared or a process still holds removed files.
+
+## Output Contract
+
+A good information-gathering result gives the next skill:
+
+- artifact root and row identity
+- outcome, status, and provenance
+- missing files or dimensions
+- high-value signal rows with source and line number
+- filter coverage and any uncovered final objects
+- explicit unknown or unclassified rows
+- a minimal raw-log read list
+- latest user request checked against the final answer topic

--- a/.agents/skills/cosim-gpu-info-gathering/scripts/codex_session_extract.py
+++ b/.agents/skills/cosim-gpu-info-gathering/scripts/codex_session_extract.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Bounded extractor for Codex JSONL session records."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+
+ALLOWED_MESSAGE_ROLES = {"user", "assistant"}
+ALLOWED_RESPONSE_TYPES = {"message", "function_call", "function_call_output"}
+SECRET_PATTERNS = [
+    re.compile(r"eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}"),
+    re.compile(r"(?i)(id_token|access_token|refresh_token|api[_-]?key|authorization)(['\" ]*[:=]['\" ]*)[^,\\s}]+"),
+]
+
+
+def compact(text: str, limit: int) -> str:
+    text = re.sub(r"\s+", " ", text.strip())
+    for pattern in SECRET_PATTERNS:
+        text = pattern.sub(lambda m: m.group(1) + m.group(2) + "[REDACTED]" if m.lastindex and m.lastindex >= 2 else "[REDACTED]", text)
+    if len(text) <= limit:
+        return text
+    return text[: limit - 3] + "..."
+
+
+def text_from_content(content: object) -> str:
+    if not isinstance(content, list):
+        return ""
+    parts: List[str] = []
+    for item in content:
+        if not isinstance(item, dict):
+            continue
+        value = item.get("text") or item.get("input_text") or item.get("output_text") or ""
+        if value:
+            parts.append(str(value))
+    return "\n".join(parts)
+
+
+def iter_records(
+    path: Path,
+    start: int,
+    end: Optional[int],
+    limit: int,
+    include_tool_output: bool,
+) -> Iterable[Dict[str, str]]:
+    source = str(path)
+    range_end = "" if end is None else str(end)
+    with path.open(errors="replace") as handle:
+        for line_no, raw in enumerate(handle, 1):
+            if line_no < start:
+                continue
+            if end is not None and line_no > end:
+                break
+            try:
+                item = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if item.get("type") != "response_item":
+                continue
+            payload = item.get("payload", {})
+            if not isinstance(payload, dict):
+                continue
+            response_type = payload.get("type", "")
+            if response_type not in ALLOWED_RESPONSE_TYPES:
+                continue
+            if response_type == "message":
+                role = str(payload.get("role", ""))
+                if role not in ALLOWED_MESSAGE_ROLES:
+                    continue
+                text = text_from_content(payload.get("content", []))
+                if not text:
+                    continue
+                yield {
+                    "source_file": source,
+                    "range_start": str(start),
+                    "range_end": range_end,
+                    "line_no": str(line_no),
+                    "record_kind": "message",
+                    "role_or_tool": role,
+                    "text": compact(text, limit),
+                }
+            elif response_type == "function_call":
+                name = str(payload.get("name", ""))
+                args = str(payload.get("arguments", ""))
+                yield {
+                    "source_file": source,
+                    "range_start": str(start),
+                    "range_end": range_end,
+                    "line_no": str(line_no),
+                    "record_kind": "function_call",
+                    "role_or_tool": name,
+                    "text": compact(args, limit),
+                }
+            elif response_type == "function_call_output":
+                if not include_tool_output:
+                    continue
+                call_id = str(payload.get("call_id", ""))
+                output = str(payload.get("output", ""))
+                if not output:
+                    continue
+                yield {
+                    "source_file": source,
+                    "range_start": str(start),
+                    "range_end": range_end,
+                    "line_no": str(line_no),
+                    "record_kind": "function_call_output",
+                    "role_or_tool": call_id,
+                    "text": compact(output, limit),
+                }
+
+
+def write_tsv(rows: Iterable[Dict[str, str]], out: Optional[Path]) -> None:
+    fields = ["source_file", "range_start", "range_end", "line_no", "record_kind", "role_or_tool", "text"]
+    if out is None:
+        writer = csv.DictWriter(sys.stdout, fieldnames=fields, delimiter="\t", lineterminator="\n")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+        return
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with out.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields, delimiter="\t", lineterminator="\n")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def write_meta(
+    out: Optional[Path],
+    session_file: Path,
+    start: int,
+    end: Optional[int],
+    text_limit: int,
+    include_tool_output: bool,
+) -> None:
+    if out is None:
+        return
+    meta = {
+        "session_file": str(session_file),
+        "start": start,
+        "end": end,
+        "text_limit": text_limit,
+        "include_tool_output": include_tool_output,
+        "output": str(out),
+    }
+    with out.with_suffix(out.suffix + ".meta.json").open("w") as handle:
+        json.dump(meta, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--session-file", required=True, type=Path, help="Exact Codex JSONL session path")
+    parser.add_argument("--start", type=int, default=1, help="First JSONL line number to inspect")
+    parser.add_argument("--end", type=int, default=None, help="Last JSONL line number to inspect")
+    parser.add_argument("--text-limit", type=int, default=700, help="Maximum text per extracted row")
+    parser.add_argument("--include-tool-output", action="store_true", help="Include redacted tool output rows")
+    parser.add_argument("--out", type=Path, default=None, help="Optional TSV output path")
+    args = parser.parse_args()
+    rows = iter_records(args.session_file, args.start, args.end, args.text_limit, args.include_tool_output)
+    write_tsv(rows, args.out)
+    write_meta(args.out, args.session_file, args.start, args.end, args.text_limit, args.include_tool_output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/cosim-gpu-launch/SKILL.md
+++ b/.agents/skills/cosim-gpu-launch/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: cosim-gpu-launch
+description: Use when you need to start the QEMU+gem5 cosim environment. Launches gem5 in Docker, QEMU with KVM on host, via vfio-user or legacy cosim socket.
+---
+
+# Cosim Launch
+
+Launch the QEMU+gem5 co-simulation environment.
+
+This is a direct launcher, not the test harness. Use it for manual boot,
+interactive inspection, backend checks, and standalone QEMU+gem5 sessions. It
+does not accept `--output-dir`, does not create test matrices, does not write
+guest program logs, and does not run binary-provenance hooks. Use `cosim-gpu-test`
+when a run must produce case-managed evidence.
+
+## Quickstart
+
+```bash
+bash scripts/cosim_cleanup.sh                    # always preflight first
+./scripts/cosim_launch.sh                        # vfio-user (default)
+./scripts/cosim_launch.sh --gem5-debug MI300XCosim  # with debug trace
+./scripts/cosim_launch.sh --cosim-backend legacy    # legacy cosim socket
+```
+
+After guest boots, the driver loads automatically via `cosim-gpu-setup.service`.
+If not, manually load with `cosim-gpu-guest`.
+
+## Autonomy
+
+Run `bash scripts/cosim_cleanup.sh` before launch without asking the user. This
+is the normal preflight for cosim and removes only known leftover cosim state.
+Do not ask before the standard launcher either. Ask only before broad manual
+cleanup outside repository scripts, deleting unrelated files, or a full/cold
+rebuild.
+
+## Backends
+
+| Backend | Protocol | Default? | Notes |
+|---------|----------|----------|-------|
+| vfio-user | `libvfio-user` over Unix socket | Yes | Standard, no custom QEMU code |
+| legacy | Custom cosim socket protocol | No | QEMU `mi300x-gem5` device |
+
+## Architecture
+
+```
+QEMU (Q35+KVM, host) ←Unix socket→ gem5 (MI300X GPU, Docker)
+```
+
+Shared memory uses run-id names: `/dev/shm/cosim-guest-ram-<run-id>` for guest RAM and `/dev/shm/mi300x-vram-<run-id>` for VRAM.
+BAR layout: 0+1=VRAM, 2+3=Doorbell, 4=MSI-X, 5=MMIO.
+
+## Driver parameters
+
+```
+ip_block_mask=0x67  # enable common/GMC/IH/GFX/SDMA; disable PSP bit 3 and SMU bit 4
+ppfeaturemask=0     # disable power play
+dpm=0               # disable dynamic power management
+audio=0             # no audio controller
+ras_enable=0        # disable RAS
+discovery=2         # firmware-based discovery
+```
+
+## Troubleshooting
+
+| Symptom | Route |
+|---------|-------|
+| gem5 container exited during launch | Use `cosim-gpu-debug` to inspect active gem5 container logs |
+| Driver failed while parsing AtomBIOS | Use `cosim-gpu-guest` or launch setup workflow to inspect ROM visibility before amdgpu loads |
+| KIQ disable timeout (-110) | Treat as expected cosim noise unless followed by a functional failure |
+| DRM client -13 / EPERM | Use guest setup or disk-image workflow to inspect permissions and image state |
+
+## Integration
+
+- **Before**: use `cosim-gpu-build` directly when binaries are stale or missing
+- **Before**: run `bash scripts/cosim_cleanup.sh` directly to clear leftover state
+- **While running**: `cosim-gpu-guest` to interact, `cosim-gpu-debug` to inspect
+- **Testing**: Prefer `cosim-gpu-test` for automated execution (handles launch internally)

--- a/.agents/skills/cosim-gpu-repo-maintenance/SKILL.md
+++ b/.agents/skills/cosim-gpu-repo-maintenance/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: cosim-gpu-repo-maintenance
+description: Use for cosim-gpu repository maintenance that is not cosim execution: submodule pointers, commit splitting, history rewrite for local commits, staged-index cleanup, author/signoff checks, ignore rules, skill hygiene audits for sensitive literals or unwanted coupling, skill routing validation after skill instruction changes, and keeping generated artifacts out of commits. Separates general Git practice from cosim-gpu-specific repository policy.
+---
+
+# Cosim Repo Maintenance
+
+Use this skill for repository hygiene in the cosim-gpu repository when the task
+does not need cosim build, launch, test, debug, review, or RLCR evidence.
+
+Examples:
+
+- locate or update the `gem5` or `gem5-resources` submodule pointer, or edit
+  the vendored `.agents` skill files
+- split a large local commit
+- rewrite local unpushed commits for better topic boundaries
+- audit skill files for sensitive literals or unwanted coupling
+- validate skill routing after skill instruction changes
+- inspect staged, unstaged, and untracked files before committing
+- keep logs, artifacts, build outputs, and scratch files out of history
+- verify commit author and `Signed-off-by`
+- update ignore rules for generated outputs
+
+Do not use `cosim-gpu-flow-plan` for ordinary repository maintenance. If the
+task starts requiring cosim test evidence, switch to the matching cosim domain
+skill.
+
+## General Git Practice
+
+These are general rules, not project-specific behavior:
+
+- Inspect before changing: `git status --short`, `git diff --stat`,
+  `git diff --cached --stat`, and submodule status when relevant.
+- Keep commits topic-scoped and reviewable.
+- Do not include unrelated working-tree changes.
+- Do not rewrite commits that may already be shared unless the user explicitly
+  asks.
+- Prefer path-limited `git add` and `git commit` over broad staging in a dirty
+  tree.
+- Never use destructive checkout or reset commands to discard unknown changes
+  without explicit user direction.
+
+## Project-Specific Rules
+
+Read `references/cosim-gpu-repo-policy.md` before changing submodule pointers,
+editing skill files, or preparing project commits.
+
+## Maintenance Workflow
+
+1. Record repository state:
+
+   ```bash
+   git status --short
+   git submodule status
+   git diff --stat
+   git diff --cached --stat
+   ```
+
+2. Classify changes by owner:
+
+   - top-level repository files, including vendored `.agents` skills
+   - `gem5` source submodule
+   - `gem5-resources` data submodule
+   - generated artifacts or local scratch
+
+3. Commit inside `gem5` or `gem5-resources` before recording their superproject
+   gitlink. `.agents` changes are ordinary top-level changes.
+
+4. For commit splitting, group by behavior and ownership. Keep generated
+   output, logs, `artifacts/`, `m5out/`, and scratch files out unless the user
+   explicitly asks to preserve a small source artifact.
+
+5. After changing skill instructions, run a routing validation pass:
+
+   - list 3-5 realistic user prompts affected by the change
+   - map each prompt to the expected skill or expected no-skill path
+   - compare against the skill frontmatter descriptions currently visible to
+     the agent
+   - check that the first loaded instructions would route to the intended
+     reference files or scripts
+   - record any prompt that still risks stale behavior or overbroad matching
+
+   This is a skill-design check, not cosim execution evidence.
+
+6. Before final reporting, show current `gem5`/`gem5-resources` submodule
+   pointers and remaining dirty files.
+
+## Commit Messages
+
+Use normal project style and include `Signed-off-by` from:
+
+```bash
+git config user.name
+git config user.email
+```
+
+Do not add AI assistant identities to trailers.

--- a/.agents/skills/cosim-gpu-repo-maintenance/references/cosim-gpu-repo-policy.md
+++ b/.agents/skills/cosim-gpu-repo-maintenance/references/cosim-gpu-repo-policy.md
@@ -1,0 +1,104 @@
+# Cosim GPU Repository Policy
+
+This file contains project-specific repository maintenance rules. General Git
+practice belongs in the main skill and should not be treated as unique to this
+project.
+
+## Repository Shape
+
+The top-level repository records two nested repositories:
+
+| Path | Meaning |
+|---|---|
+| `.agents` | reusable cosim GPU skills vendored in-tree |
+| `gem5` | simulator source submodule |
+| `gem5-resources` | resources and guest image inputs |
+
+The superproject records `gem5` and `gem5-resources` commits as gitlinks.
+`.agents` is ordinary top-level content with no separate skill repository or
+gitlink. A dirty submodule work tree is not the same as a changed superproject
+pointer.
+
+## Skill Location
+
+Reusable workflows live in `.agents/skills/` and are tracked directly by this
+repository. Do not add new project-specific command implementations under
+`.claude/commands`.
+
+`AGENTS.md` and `CLAUDE.md` map to the top-level agent rules. Keep skill path
+references current when skill folders are renamed.
+
+## Commit Ownership
+
+- Changes inside `.agents` are ordinary top-level repository changes and are
+  committed directly in cosim-gpu.
+- Changes inside `gem5` or `gem5-resources` must be committed in that submodule
+  first. Then commit the top-level gitlink pointer.
+- Top-level script, docs, tests, and ignore-rule changes belong to the
+  superproject.
+- Do not mix `gem5` or `gem5-resources` internal source changes and top-level
+  pointer updates in one submodule commit; they are different repositories.
+
+## Project Commit Rules
+
+- gem5: pre-commit hooks apply; use tags from `MAINTAINERS.yaml` when relevant.
+- Top-level cosim-gpu: no project-specific hooks.
+- Sign commits with `Signed-off-by` from top-level git config unless the
+  submodule has its own required author identity.
+
+## Generated Outputs
+
+Default exclude list for commits:
+
+- `artifacts/`
+- `m5out/`
+- `local-cosim-runs/`
+- `*.log`
+- test `.out`, `.strace`, `.gdb`, `.proc`, and guest-run files
+- local scratch scripts or one-off command transcripts unless explicitly
+  promoted to repository scripts or docs
+
+If a generated file is needed as durable evidence, prefer placing a concise
+source document under `docs/` or an artifact summary under a task workspace.
+
+## Documentation Pairing
+
+Project docs under `docs/` must keep both `docs/zh/` and `docs/en/` versions.
+The first line links to the other language version:
+
+```text
+[English](../en/<file>.md)
+[中文](../zh/<file>.md)
+```
+
+When adding or modifying project docs, update both languages unless the file is
+explicitly a temporary patch or source evidence artifact.
+
+## Safe Submodule Pointer Review
+
+Before committing a submodule pointer (`gem5` or `gem5-resources`; `.agents`
+is vendored and has no pointer):
+
+```bash
+git submodule status
+git -C <submodule> status --short
+git -C <submodule> log --oneline -1
+git diff --submodule=short -- <submodule>
+```
+
+If the submodule has local commits, confirm the top-level pointer records the
+intended final commit. If the submodule is dirty, finish or separate that work
+before committing the pointer.
+
+## Splitting Skill Changes
+
+For `.agents` skill work (now vendored in this repository), prefer commit
+boundaries by reader-facing behavior:
+
+- routing or trigger changes
+- shared review or workflow contracts
+- test, build, or debug reference extraction
+- project policy or repository maintenance skills
+
+After splitting, verify the final tree matches the intended working tree and
+that references point to existing files.

--- a/.agents/skills/cosim-gpu-review/SKILL.md
+++ b/.agents/skills/cosim-gpu-review/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: cosim-gpu-review
+description: Use when reviewing cosim changes, preparing PR evidence, or delegating independent review. Requires a confirmed review target from cosim-gpu-flow-plan unless the user supplies an explicit standalone review brief.
+---
+
+# Cosim Review
+
+Review local cosim changes through an independent reviewer workflow. This skill
+owns review orchestration, finding disposition, and PR-ready evidence. Shared
+reviewer isolation, prompt hygiene, source-base, build, and formatting rules
+live in `references/review/independent-review-contract.md`; read that file
+before delegation or maintainer audit.
+
+## Entry Rules
+
+- Start from a `cosim-gpu-flow-plan --type review` plan whose Confirmed Target
+  section is complete.
+- Exception: if the user explicitly supplies a standalone review brief, inspect
+  only the files and artifacts permitted by that brief, do not modify source,
+  and return findings ordered by severity.
+- Map older names such as `cosim-review` to this skill.
+- The user controls round count and stopping rule when they supply them.
+  Default: one independent review round, followed by maintainer audit.
+- When invoked from `cosim-gpu-rlcr-loop`, follow the RLCR stop rule instead of
+  asking after each clean round.
+
+Ask only before widening reviewed scope, changing base reference, changing
+target programs or fixed environment rows, using a nonstandard binary,
+requesting a full or cold rebuild, editing a disk image, deleting files outside
+repository cleanup scripts, accessing external services, or creating a pull
+request.
+
+## Workflow
+
+1. Read `references/review/independent-review-contract.md`.
+2. Read optional domain references when relevant:
+   - `references/review/gem5-format-hygiene.md` for gem5 formatter scope,
+     commit splitting, or style churn.
+   - `references/review/github-actions-ci.md` for GitHub Actions YAML.
+3. Write `artifacts/<slug>/reviews/review-round-N-brief.md` from `plan.md`,
+   scoped diffs, test evidence, and public review comments.
+4. Send the brief to an independent reviewer through `cosim-gpu-codex-review`.
+5. Save output as
+   `artifacts/<slug>/reviews/review-round-N-adversarial.md`.
+6. Audit every finding and save
+   `artifacts/<slug>/reviews/review-round-N-audit.md`.
+7. Update `artifacts/<slug>/review-findings.md` with accepted, rejected, fixed,
+   or deferred status.
+8. After accepted source or behavior changes, run the standard incremental
+   build and affected test rows through `cosim-gpu-build` and `cosim-gpu-test`.
+
+If an accepted finding only requests validation coverage, convert it into
+explicit test manifest rows. Add only rows already inside the confirmed scope;
+return to planning if the requested validation changes program family, binary,
+live debug mode, or environment policy.
+
+## Maintainer Audit
+
+The maintainer audit is broader than pass/fail evidence. For each changed area,
+judge whether the design can be smaller or clearer: ownership, mutable state,
+duplicated completion paths, callback ordering, local invariants, and public
+surface. Record accepted design cleanup separately from correctness fixes.
+
+## Stop And Output
+
+Stop when the requested round count or stopping rule is satisfied, all accepted
+findings are fixed or deferred with reason, final evidence satisfies build and
+provenance gates, and non-PASS rows have debug or invocation-error records.
+
+For PR preparation, write `artifacts/<slug>/pr-body.md` with summary,
+motivation, changes, verification commands, and risk notes. Do not create a PR
+unless the user explicitly asks.

--- a/.agents/skills/cosim-gpu-review/references/review/gem5-format-hygiene.md
+++ b/.agents/skills/cosim-gpu-review/references/review/gem5-format-hygiene.md
@@ -1,0 +1,63 @@
+# Gem5 Format Hygiene Review
+
+Use this reference when reviewing gem5 changes that may contain formatter churn,
+commit splitting mistakes, or mixed style and behavior edits.
+
+## Goal
+
+Keep behavior commits semantically reviewable. Formatting is acceptable only
+when it is limited to touched hunks and immediate context, or when it is
+isolated in a confirmed formatting-only commit.
+
+## Required Checks
+
+1. Inspect every reviewed commit individually. A later commit that removes or
+   rewrites the same function does not excuse style-only churn in an earlier
+   behavior commit.
+2. Compare ordinary diff output with whitespace-ignored output:
+   `git -C gem5 diff --stat <base>..<head>` and
+   `git -C gem5 diff -w --stat <base>..<head>`. For single commits, replace
+   the range with `<commit>^!`.
+3. Check formatter scope before accepting the patch. Prefer gem5 modified-range
+   tooling such as `util/run-git-clang-format.py --pre-commit`, `git-clang-format
+   --diff <base> HEAD --style=file`, or `util/style.py -m` from inside the
+   `gem5/` worktree.
+4. Run `git -C gem5 diff --check <range>` or the equivalent staged range check
+   before final acceptance.
+5. When formatter churn is found in a behavior commit, classify it as a commit
+   hygiene defect until the churn is moved to a formatting-only commit or
+   removed from the behavior diff.
+
+## High-Risk Areas
+
+Always scan these areas manually because formatters often change them without
+changing behavior:
+
+- log and diagnostic calls, including `DPRINTF`, `panic`, `warn`, and fatal
+  messages
+- long format strings and argument wrapping
+- function signatures and multi-line call sites
+- lambda capture lists
+- pointer and reference declarations
+- short helper methods that a formatter expands or collapses
+- local boolean conditions and arithmetic expressions wrapped only for column
+  width
+
+## Gem5 Formatter Caveat
+
+Gem5 has repository style tooling, but broad formatter ranges can still rewrite
+old code toward the current `.clang-format` approximation. That output may be
+style-correct yet unrelated to the behavior under review. Treat the modified
+range as part of the evidence: if the range is wider than the true semantic
+change, the resulting diff is not acceptable in a behavior commit.
+
+## Evidence To Record
+
+Record these items in the review artifact:
+
+- base and head commit hashes plus commit messages
+- per-commit diff command used for inspection
+- ordinary and whitespace-ignored diff stats
+- formatter command and range
+- any isolated formatting-only commit subject
+- final statement that behavior commits contain no unrelated formatter churn

--- a/.agents/skills/cosim-gpu-review/references/review/github-actions-ci.md
+++ b/.agents/skills/cosim-gpu-review/references/review/github-actions-ci.md
@@ -1,0 +1,43 @@
+# GitHub Actions CI Review
+
+Use this reference when reviewing `.github/workflows/*.yml` or `.yaml`
+changes, especially path-classified fast paths and aggregate required checks.
+
+## Required Checks
+
+1. List every job referenced through `needs.<job>.result` or
+   `needs.<job>.outputs.*`, then verify that each job is present in the
+   aggregate job's `needs:` list.
+2. Check both lanes of any classifier output. For each lane, name which jobs
+   must be `success`, which jobs may be `skipped`, and which skipped job would
+   indicate a missing gate.
+3. Treat workflow-file changes as full-CI unless the task explicitly proves a
+   safe narrower policy. CI logic should not validate itself only through the
+   fast path it edits.
+4. For shell `case` classifiers, verify actual pattern semantics with a small
+   shell command when the result matters. In POSIX shell patterns, `*` can match
+   `/`, so `src/dev/amdgpu/*` may cover deeper paths.
+5. Separate allow-list and deny-list reasoning. Files that can affect vfio-user,
+   architecture build scripts, unit tests, or shared headers used by full-CI
+   targets should either force full CI or have a recorded reason why the fast
+   path is sufficient.
+6. Verify that adding a fast-path job does not add work to general PRs. A
+   replacement job should run only on the lane where it replaces skipped broad
+   checks.
+
+## Evidence To Record
+
+- Workflow file path, base commit, and head commit or working tree path.
+- The classifier variable names and all possible values.
+- A table of lane to required jobs.
+- Any shell pattern probes used to confirm classifier behavior.
+- Any path class intentionally forced to full CI, such as workflow files,
+  vfio-user sources, architecture build scripts, or test infrastructure.
+
+## Finding Rules
+
+Classify as high severity when a relevant path can reach the aggregate required
+check without a required compile, unit, quick-test, vfio-user, macOS, clang, or
+GPU gate. Classify as medium when the workflow is safe but does extra work for
+general PRs or has brittle classifier coverage that should be narrowed before
+merge.

--- a/.agents/skills/cosim-gpu-review/references/review/independent-review-contract.md
+++ b/.agents/skills/cosim-gpu-review/references/review/independent-review-contract.md
@@ -1,0 +1,69 @@
+# Independent Review Contract
+
+Use this contract from `cosim-gpu-review`, `cosim-gpu-rlcr-loop`, and
+`cosim-gpu-codex-review` whenever an independent reviewer is used.
+
+## Brief Isolation
+
+The reviewer starts from a written brief, not from the implementer's
+conversation state. The brief may include:
+
+- confirmed target from `plan.md`
+- reviewed base, current `HEAD`, ancestry status, and file scope
+- exact diff commands or scoped diffs
+- required tests, matrix rows, verdicts, logs, and provenance paths
+- prior public review comments
+
+The brief must not include the implementer's intended fix, suspected mechanism,
+private rationale, or dialogue-derived conclusions unless those claims are
+already recorded in an artifact with command, path, and observed result.
+
+## Reviewer Checklist
+
+Ask the reviewer to inspect:
+
+- new bugs introduced by the diff
+- caller and callee contracts, assertions, initialization, and local invariants
+- completion, callback, cleanup, and error paths that must execute exactly once
+- ownership of memory, events, descriptors, and context values
+- sibling call sites, wrappers, callbacks, reverse-direction operations, and
+  default arguments that may still contain the same bug pattern
+- formatter churn, debug leftovers, unrelated scope expansion, and commit hygiene
+- whether tests prove the requested programs, current source, rebuilt binary,
+  and `cosim-gpu-build` provenance gate
+- whether each finding still applies to current `HEAD` when the reviewed change
+  is historical
+
+## Source And Verification Rules
+
+Source optimization edits target checked-out `HEAD`. Historical commits may
+define review intent, but fixes and cleanup apply to current files unless the
+user explicitly requests history rewriting.
+
+After any accepted source or behavior change, run the standard incremental
+build through `cosim-gpu-build` and rerun affected rows. This is mandatory
+verification inside the confirmed target, not a separate approval point. If the
+execution platform blocks the command, request only the narrow build-script
+authorization.
+
+Source edits must use diff-scoped formatting. Whole-file or project-wide
+formatter churn mixed with behavior changes fails review hygiene unless the
+task is explicitly formatting-only. When formatter scope is in question, record
+normal and whitespace-ignored diff stats.
+
+For gem5 source changes, use gem5 repository tooling from inside `gem5/`.
+Generic top-level format checks do not prove gem5 CI style.
+
+## Evidence Records
+
+Each independent review round records:
+
+- the brief
+- reviewer output
+- maintainer audit
+- disposition for each finding: accepted, rejected, fixed, or deferred with
+  reason
+- final build, provenance, and test evidence after accepted changes
+
+Non-PASS rows go through `cosim-gpu-debug` or are recorded as invocation errors
+with the artifact path and verdict reason.

--- a/.agents/skills/cosim-gpu-rlcr-loop/SKILL.md
+++ b/.agents/skills/cosim-gpu-rlcr-loop/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: cosim-gpu-rlcr-loop
+description: Use for iterative cosim implementation, debugging, or validation after cosim-gpu-flow-plan. Runs bounded rounds until frozen acceptance criteria and independent review gates pass.
+---
+
+# Cosim RLCR Loop
+
+Run iterative implementation or debugging after `cosim-gpu-flow-plan`. This
+skill owns round state, acceptance criteria, interruption recovery, and the
+order of build, test, and review gates. Independent reviewer rules live in
+`../cosim-gpu-review/references/review/independent-review-contract.md`; read
+that file before each review gate.
+
+## Required Inputs
+
+- `artifacts/<task-slug>/plan.md`
+- frozen acceptance criteria
+- chosen domain skill for the technical work
+- build and provenance gate from `cosim-gpu-build`
+- current `HEAD` recorded as the source-edit base
+
+If there is no plan, run `cosim-gpu-flow-plan` first.
+
+## Artifact Layout
+
+```text
+artifacts/<task-slug>/rlcr/
+├── goal-tracker.md
+├── round-001-summary.md
+├── round-001-review.md
+└── final-summary.md
+```
+
+Logs, review briefs, verdicts, and provenance stay in the task workspace under
+`logs/`, `reviews/`, `tests/`, or existing artifact paths.
+
+## Goal Tracker
+
+Maintain `rlcr/goal-tracker.md`:
+
+```markdown
+# Goal Tracker
+
+## Immutable
+- Goal:
+- Acceptance Criteria:
+
+## Mutable
+- Active round:
+- Completed:
+- Remaining:
+- Deferred with reason:
+- Decision log:
+```
+
+Do not change the immutable section without explicit human approval.
+
+## Round Loop
+
+Repeat until all acceptance criteria pass and the independent review stop rule
+is satisfied.
+
+Stop rules apply in this order:
+
+- user-supplied stop rule in `plan.md` or `goal-tracker.md`
+- frozen acceptance criteria plus required evidence gates
+- default convergence: two consecutive independent reviews with no new
+  `BLOCKER` or `MAJOR` findings
+
+Each round:
+
+1. Select the smallest coherent objective that advances a named acceptance
+   criterion.
+2. Re-read current evidence, acceptance criteria, source base, and pending
+   findings.
+3. For bug/debug tasks, write at least two mutually exclusive hypotheses to
+   `scratch/hypotheses.md` before source edits.
+4. Implement or investigate using the selected domain skill.
+5. After any source change, treat prior test rows as non-final.
+6. Run the standard incremental build and relevant test rows.
+7. Write `rlcr/round-NNN-summary.md` with commands, artifacts, verdicts,
+   source base, and remaining work.
+8. Run the independent review gate through `cosim-gpu-review` or
+   `cosim-gpu-codex-review`, following the shared review contract.
+9. Audit findings, fix accepted in-scope issues, and defer wider redesigns with
+   reasons.
+
+Ask only when the next action would alter the immutable goal, widen source or
+test scope, use a nonstandard binary, perform a full or cold rebuild, edit a
+disk image, access external services, or create public artifacts.
+
+## Interruption Recovery
+
+After interruption or context compaction, reconstruct state from artifacts:
+
+- `plan.md`
+- `rlcr/goal-tracker.md`
+- latest round summary and review files
+- `evidence.md`, `commands.md`, matrix rows, verdicts, and provenance
+- live build or test processes
+
+If no live process remains and the artifact lacks a valid verdict or review
+result, classify the interrupted step as incomplete and resume the next missing
+step inside the frozen scope. Do not ask whether to continue when the remaining
+step is already authorized by the plan.
+
+If `HEAD` moved, record the new value and reclassify pending findings against
+current source before editing.
+
+## Verification Gate
+
+Use the narrowest relevant gate first:
+
+- build readiness through `cosim-gpu-build`
+- provenance artifacts from the standard test path
+- smoke row for the changed path
+- exact target rows named by the plan, user, or reviewer
+- variants such as interrupt mode or repeated runs only when required
+- independent review through the shared review contract
+
+The final row must have `verdict.json` or a `[COSIM_VERDICT]` line. Do not
+override verdict artifacts by interpreting logs manually.
+
+## Final Output
+
+Write `rlcr/final-summary.md` with:
+
+- acceptance criteria status
+- final source base and touched repositories
+- build and test commands
+- verdict, matrix, and provenance paths
+- accepted, fixed, rejected, and deferred review findings
+- remaining risks outside the frozen scope

--- a/.agents/skills/cosim-gpu-rocm-stack/SKILL.md
+++ b/.agents/skills/cosim-gpu-rocm-stack/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: cosim-gpu-rocm-stack
+description: Read before debugging guest-side ROCm behavior such as HSA signals, HIP waits, KFD ioctls, driver parameters, PASID/VMID routing, or known cosim runtime quirks.
+---
+
+# Cosim ROCm Stack
+
+Use this as the guest-side ROCm routing guide. It explains when a symptom
+belongs to test policy, guest inspection, debug evidence, or model-side review.
+Detailed runtime semantics live in `references/rocm-runtime-reference.md`; read
+that file when debugging HSA signals, HIP API waits, KFD ioctls, PASID, VMID, or
+driver parameters.
+
+## Stack Overview
+
+```text
+HIP API
+  -> ROCclr
+    -> ROCr / HSA runtime
+      -> amdgpu KFD
+        -> amdgpu DRM
+          -> gem5 GPU model through QEMU
+```
+
+## Routing
+
+| Question | First route |
+|---|---|
+| Environment defaults or `HSA_ENABLE_INTERRUPT` | `cosim-gpu-test`, then `scripts/cosim_guest_env.sh` |
+| Guest device visibility, driver load, debugfs | `cosim-gpu-guest` |
+| Non-PASS row, hang, crash, or timeout | `cosim-gpu-debug` |
+| Disk image package or service changes | `cosim-gpu-disk-image-edit` |
+| HSA signal, HIP wait, KFD ioctl, PASID or VMID meaning | `references/rocm-runtime-reference.md` |
+
+## Evidence To Collect
+
+Use `cosim-gpu-guest` and `cosim-gpu-debug` to collect:
+
+- amdgpu and KFD kernel log excerpts
+- PCI device state and loaded kernel modules
+- ROCm agent and memory visibility
+- KFD debugfs state when signal or queue progress is suspected
+- program identity, interrupt mode, verdict, matrix row, and artifact path
+
+When runtime symbols or debug builds are needed, use repository scripts and
+`cosim-gpu-disk-image-edit`; do not embed package-install procedures in this
+skill.

--- a/.agents/skills/cosim-gpu-rocm-stack/references/rocm-runtime-reference.md
+++ b/.agents/skills/cosim-gpu-rocm-stack/references/rocm-runtime-reference.md
@@ -1,0 +1,107 @@
+# ROCm Runtime Reference
+
+Read this when debugging guest-side HSA, HIP, KFD, PASID, VMID, or driver
+parameter behavior.
+
+## Driver Parameters
+
+```text
+ip_block_mask=0x67
+ppfeaturemask=0
+dpm=0
+audio=0
+ras_enable=0
+discovery=2
+```
+
+`ip_block_mask` uses discovery order indexes, not `amd_ip_block_type` enum
+values. `0x67` disables PSP at discovery bit 3 and SMU at discovery bit 4 while
+keeping blocks needed for driver bring-up and command execution.
+
+## HSA Signals
+
+Signal flow:
+
+```text
+Kernel finishes
+  -> GPU writes signal value
+  -> CP_EOP interrupt
+  -> amdgpu_ih_process()
+  -> kfd_signal_event()
+  -> HIP runtime observes signal change
+```
+
+Key structures:
+
+- Signal object: 64-bit GPU-visible completion value.
+- CP_EOP interrupt: end-of-pipe, carries PASID/VMID.
+- TRAP interrupt: exception or fault path.
+
+Common cosim issues:
+
+- Signal does not complete: wrong VMID/PASID routing, stale PWC entry, or cache
+  visibility issue.
+- Signal completes but buffer content is stale: launch-time cache state or
+  different CP/CU cache paths.
+- `vector_add` remains a real signal-path baseline because it exercises memcpy,
+  kernel completion, synchronization, and `hipFree`.
+
+Guest workload environment is centralized in `scripts/cosim_guest_env.sh`.
+`HSA_ENABLE_INTERRUPT=0` uses polling; `HSA_ENABLE_INTERRUPT=1` tests interrupt
+routing.
+
+## HIP API To HSA
+
+| HIP API | HSA mechanism | Signal |
+|---|---|---|
+| `hipMalloc` | memory pool allocation | No |
+| `hipMemcpy` | SDMA or blit copy | Yes |
+| `hipLaunchKernel` | AQL dispatch packet | Yes |
+| `hipFree` | memory pool free | Yes |
+| `hipDeviceSynchronize` | wait on pending signals | Yes |
+| `hipStreamSynchronize` | wait on queue signal | Yes |
+
+`hipFree` involves a signal wait, so programs with `hipFree` can hang on signal
+completion while smaller kernels may appear to work.
+
+## KFD Ioctls
+
+| ioctl | Purpose |
+|---|---|
+| `AMDKFD_IOC_CREATE_QUEUE` | Create HSA user-mode queue |
+| `AMDKFD_IOC_DESTROY_QUEUE` | Destroy queue |
+| `AMDKFD_IOC_SET_MEMORY_POLICY` | Set memory access policy |
+| `AMDKFD_IOC_ALLOC_MEMORY_OF_GPU` | Allocate GPU-visible memory |
+| `AMDKFD_IOC_MAP_MEMORY_TO_GPU` | Map memory into GPU page table |
+| `AMDKFD_IOC_UNMAP_MEMORY_FROM_GPU` | Unmap from GPU page table |
+
+## Known Cosim Quirks
+
+| Symptom | Meaning | Route |
+|---|---|---|
+| KIQ disable timeout | Expected firmware-model gap unless paired with failure |
+| DRM client EPERM | Render permissions or stale guest image |
+| Device-side printf hangs | Test policy input for `cosim-gpu-test` |
+| AtomBIOS null dereference | ROM visibility issue |
+| gem5 container exited | Use `cosim-gpu-debug` |
+
+## PASID And VMID
+
+AMD IOMMU partitions PASID space:
+
+```text
+0x0000 .. 0x7FFF  system / GPU internal
+0x8000 .. 0xFFFF  user processes
+```
+
+KFD allocates the first user PASID at `0x8000`. gem5 constants:
+
+- `AMDGPU_FIRST_USER_PASID = 0x8000`
+- `AMDGPU_FIRST_COMPUTE_VMID = 8`
+
+VMID is allocated per process, not per stream. Multiple HIP streams in one
+process share the same VMID. Multi-VMID testing requires multiple independent
+processes.
+
+See `../../cosim-gpu-debug/references/gem5-model/vmid-pasid-architecture.md`
+for model-side VMID/PASID behavior.

--- a/.agents/skills/cosim-gpu-test/SKILL.md
+++ b/.agents/skills/cosim-gpu-test/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: cosim-gpu-test
+description: Use when running GPU programs against cosim and classifying outcomes. Requires exact program identity, fresh-session runner use, verdict artifacts, and provenance checks. After cosim-gpu-flow-plan for planned test tasks.
+---
+
+# Cosim Test
+
+Execute GPU programs against cosim and classify results. The test runner owns
+launching, guest execution, artifact routing, source snapshot, provenance,
+matrix rows, verdicts, and cleanup.
+
+Use `cosim-gpu-launch` only for manual boot or interactive inspection. Use this
+skill whenever a program result, matrix row, verification result, or PR-grade
+test artifact is required.
+
+## Quickstart
+
+```bash
+bash scripts/run_cosim_tests.sh vector_add
+bash scripts/run_cosim_tests.sh --all
+bash scripts/run_cosim_tests.sh HIP-Basic/FloydWarshall
+bash scripts/run_cosim_tests.sh --test-timeout 120 --output-dir artifacts/<slug> vector_add
+bash scripts/run_cosim_tests.sh --hang-env --output-dir artifacts/<slug> bit_extract_sync
+```
+
+`scripts/run_cosim_tests.sh` has two modes:
+
+- `pure_test`: fresh cosim session, guest workload, classification, artifact
+  archive, cleanup.
+- `hang_env`: launch cosim, mount the shared repository, build the target,
+  write `category=hang_env_ready`, and leave the console pipe alive for
+  `cosim-gpu-guest`.
+
+Normal tests always archive evidence and clean the live session.
+
+## Required Gates
+
+Before launching a named program, prove exact program identity. Read
+`references/program-identity-and-guest-env.md` for local kernels, ROCm
+examples, variants, timeout estimation, device-side `printf`, or
+`GUEST_TEST_PREFIX`.
+
+Before automated rows, repeats, environment matrices, non-default binaries, or
+evidence intended to prove uncommitted source, read
+`references/run-manifest-and-provenance.md`.
+
+For long diagnostic rows, performance rows, matrix runs, or interrupted test
+automation, read `references/diagnostic-and-matrix-runs.md`.
+
+Use `cosim-gpu-build` for build readiness and binary provenance decisions. Do
+not duplicate build metadata rules here.
+
+## Automation Rule
+
+When program identity, manifest rows, and required provenance checks are
+complete, run `scripts/run_cosim_tests.sh` directly. Do not ask before standard
+test execution, repeats, interrupt-mode matrix rows, timeout probes, post-fix
+reruns inside the current scope, standard incremental build, or standard
+preflight cleanup.
+
+Ask only before changing target program, changing fixed environment values,
+using a nonstandard binary, full or cold rebuilds, deletion outside repository
+cleanup scripts, or switching from normal test mode to live debug mode when the
+target is not already known to hang.
+
+## Result Classification
+
+Tests are classified by `scripts/classify_runs.py --json`. The agent must read
+`[COSIM_VERDICT]` or `verdict.json` from the test artifact and report the
+outcome verbatim. Do not override verdict artifacts by manually interpreting
+logs.
+
+| Outcome | Meaning | Action |
+|---------|---------|--------|
+| `PASS` | Program ran, output validated, exit 0 | Record and proceed |
+| `FAIL` | Anything not PASS | Route by verdict reason |
+
+Use verdict `reason` for routing. Examples: timeout, wrong result, simulator
+death, boot timeout, or invocation error. If QEMU or gem5 exits before the
+guest test starts, treat it as launcher/backend evidence, not a program result.
+
+For existing logs:
+
+```bash
+python3 scripts/classify_runs.py --log-dir artifacts/<slug>/logs [--matrix artifacts/<slug>/matrix.tsv]
+```
+
+## Integration
+
+- Before planned test work: `cosim-gpu-flow-plan --type test`
+- Before accepting evidence: build/provenance gate from `cosim-gpu-build`
+- Before launch: `bash scripts/cosim_cleanup.sh`
+- After any non-PASS row: `cosim-gpu-debug`
+- Output authority: per-row artifacts under `artifacts/<slug>/`, matrix rows,
+  guest logs, gem5 log, QEMU log, verdict, source snapshot, and binary
+  provenance
+
+Final matrices must prove program identity, outcome, guest log, artifact path,
+gem5 commit, gem5 binary path, and gem5 binary hash for every accepted row.
+Manifest values are pre-run contracts, not proof of execution.

--- a/.agents/skills/cosim-gpu-test/references/diagnostic-and-matrix-runs.md
+++ b/.agents/skills/cosim-gpu-test/references/diagnostic-and-matrix-runs.md
@@ -1,0 +1,94 @@
+# Diagnostic And Matrix Runs
+
+Read this for long timeouts, performance rows, interrupt-mode matrices, repeat
+runs, or interrupted matrix automation.
+
+## Flow Checkpoint Execution
+
+For an interrupted matrix run, reconstruct state from:
+
+- `artifacts/<task-slug>/tests/run-manifest.tsv`
+- top-level `matrix.tsv`
+- live `run_cosim_tests.sh`, `cosim_launch.sh`, QEMU, and gem5 processes
+- per-row `verdict.json` or `[COSIM_VERDICT]`
+- binary provenance and effective environment rows
+
+Treat an interrupted row without verdict as incomplete. If no live process
+remains, rerun it with the exact manifest command and output directory. If a
+per-row artifact has a verdict but the top-level matrix lacks the row, append
+only after the artifact matches the manifest. Otherwise rerun.
+
+For many fixed rows or partial matrix state, also read
+`manifest-checkpoint-automation.md`.
+
+## Diagnostic Rows
+
+For timeout confirmation or throughput investigation, launch one fixed
+manifest row and wait for the runner artifact. Do not poll live output as final
+evidence. Use `cosim-gpu-info-gathering` for archived summaries before reading
+large logs.
+
+When debug flags are used, record:
+
+```text
+diagnostic_purpose=confirm_hang|throughput_probe|queue_probe|signal_probe
+observation_dimension=progress|queue|signal|pressure|failure
+debug_flags=<exact gem5 debug flags>
+```
+
+Prefer compact generated tables when available:
+
+- `coverage.tsv`
+- `filter_coverage.tsv`
+- `progress.tsv`
+- `queue.tsv`
+- `signals.tsv`
+- `diagnostic-summary.tsv`
+
+Classify timeout as `slow_progress` when dispatch or completion counters keep
+changing. Classify it as a wait candidate only when counters, guest output, and
+relevant queue or signal observations stop changing or are missing in a way
+that requires a targeted follow-up.
+
+If diagnostic filters do not cover final waiting objects, mark
+`coverage_insufficient`, not absence of the event.
+
+## Performance Rows
+
+Keep runner wall time, host CPU time, guest workload window, event counts,
+completion counts, verdict, binary hash, source fingerprint, and candidate diff
+in one artifact set.
+
+When parsing `/usr/bin/time -v`, preserve raw elapsed text and convert formats
+`SS`, `M:SS`, and `H:MM:SS`. Split label and value with the first `": "`
+delimiter so elapsed values stay intact.
+
+Report both runner wall-clock change and target workload window when available.
+If internal event counts improve but runner wall time does not move, classify
+the result as local cleanup or secondary optimization.
+
+## Matrix Runs
+
+For multiple programs, interrupt modes, or repeats, create one top-level
+`matrix.tsv` under the task artifact directory and append one row per accepted
+run.
+
+For interrupt-mode rows:
+
+```bash
+GUEST_TEST_PREFIX="HSA_ENABLE_INTERRUPT=0" bash scripts/run_cosim_tests.sh <program>
+GUEST_TEST_PREFIX="HSA_ENABLE_INTERRUPT=1" bash scripts/run_cosim_tests.sh <program>
+```
+
+Accept interrupt mode only from `[COSIM_ENV] HSA_ENABLE_INTERRUPT=<value>` in
+guest logs or from matrix data generated from that line.
+
+Required matrix columns:
+
+```text
+program	hsa_interrupt	run	session_id	outcome	exit_code	reason	artifact_dir
+```
+
+For any non-PASS row, report row, artifact directory, and verdict reason, then
+invoke `cosim-gpu-debug`. If all rows pass, report pass count, gem5 commit,
+gem5 binary hash, and matrix path.

--- a/.agents/skills/cosim-gpu-test/references/manifest-checkpoint-automation.md
+++ b/.agents/skills/cosim-gpu-test/references/manifest-checkpoint-automation.md
@@ -1,0 +1,62 @@
+# Manifest Checkpoint Automation
+
+Use this reference when a cosim test or debug matrix is driven by
+`tests/run-manifest.tsv` and work was interrupted, compacted, or split across
+multiple Codex turns.
+
+## Authority Order
+
+1. Exact row in `tests/run-manifest.tsv`.
+2. Per-row `metadata.txt`, `verdict.json`, `matrix.tsv`, and
+   `patch/binary-provenance.txt`.
+3. Top-level `matrix.tsv` or task evidence file.
+4. Chat observations, only after they have been converted into artifact facts.
+
+Do not treat chat text, partial terminal output, or live container output as a
+final result when archived runner files exist.
+
+## Row State
+
+Classify each manifest row before acting:
+
+- `complete`: artifact directory is unique, `verdict.json` or
+  `[COSIM_VERDICT]` exists, matrix row exists, effective environment matches the
+  manifest, and binary provenance contains the required gem5 fields.
+- `incomplete-live`: the row lacks a verdict and a matching runner, QEMU, or
+  gem5 process is alive.
+- `incomplete-dead`: the row lacks a verdict and no matching live process
+  remains.
+- `invalid`: program identity, environment, binary path, output directory, or
+  provenance does not match the manifest.
+
+## Actions
+
+- For `complete`, summarize the archived verdict and provenance. Do not rerun.
+- For `incomplete-live`, wait for the runner artifact unless the debug plan
+  explicitly asks for bounded live-state sampling.
+- For `incomplete-dead`, rerun the exact manifest row with the same output
+  directory, binary, timeout, environment, and runner argument.
+- For `invalid`, record a preflight or provenance failure and do not substitute
+  a nearby program, timeout, binary, or environment.
+
+## Long Timeout Rows
+
+For rows intended to test larger time budgets, verify the guest-side archived
+script or metadata shows the requested timeout. If the runner command used a
+longer host timeout but the guest script still contains the old timeout, mark
+the row as an invocation defect rather than model evidence.
+
+When a row times out with valid long-timeout evidence, classify from archived
+logs only. Prefer compact extracted facts: last completion count, last dispatch
+count, active wave state, fatal or panic presence, and binary provenance.
+
+## Evidence Record
+
+Record the following in the task evidence:
+
+- manifest row identifier and exact output directory
+- live process decision, if the row was interrupted
+- final verdict source file
+- effective guest environment
+- gem5 source commit, commit subject, binary path, and binary hash
+- whether the timeout value was proven inside the guest-side artifact

--- a/.agents/skills/cosim-gpu-test/references/program-identity-and-guest-env.md
+++ b/.agents/skills/cosim-gpu-test/references/program-identity-and-guest-env.md
@@ -1,0 +1,102 @@
+# Program Identity And Guest Environment
+
+Read this before launching a specified program, a ROCm example, a variant
+kernel, or any row using guest environment prefixes.
+
+## Program Identity
+
+Before each specified program, prove the exact relative path and record it in
+the active evidence file.
+
+Local kernels:
+
+```text
+source: tests/kernels/<program>.cpp
+binary: tests/build/<program>
+runner argument: <program>
+```
+
+ROCm examples:
+
+```text
+source directory: external/rocm-examples/<relative-case-dir>
+runner argument: <relative-case-dir>
+```
+
+Use exact checks:
+
+```bash
+test -f tests/kernels/<program>.cpp
+test -x tests/build/<program> || make -C tests <program>
+test -d external/rocm-examples/<relative-case-dir>
+test -f external/rocm-examples/<relative-case-dir>/Makefile
+```
+
+When a task created a variant, test that exact variant. Do not substitute a
+base program or nearby name. If the exact file or directory cannot be proven,
+record `MISSING_PROGRAM` with the requested path and discovery output.
+
+If a local filter can match multiple kernels, resolve the exact
+`tests/kernels/<program>.cpp` first and pass only the unique basename.
+
+For ROCm examples, separate build-entry failures from program failures. A
+directory with `CMakeLists.txt` but no `Makefile`, dependency skip, or missing
+guest binary is a runner or build adaptation issue until a real target binary
+executes.
+
+## Two-Phase Timeout
+
+Probe first unless a benchmark entry exists:
+
+```bash
+bash scripts/run_cosim_tests.sh --test-timeout 30 vector_add
+```
+
+If the program completes, record wall-clock time. If it times out, double the
+timeout and retry once.
+
+Then use the estimator:
+
+```bash
+python3 tests/estimate_rocm_timeout.py --untested
+python3 tests/estimate_timeout.py --test-bin tests/build/vector_add
+```
+
+Fallback defaults:
+
+- local kernels: 60 seconds
+- ROCm examples: 120 seconds
+- known large grids: 300 seconds
+
+## Device-Side Printf
+
+Programs with device-side `printf` in kernel code hang in cosim. The estimator
+flags these:
+
+```bash
+python3 tests/estimate_rocm_timeout.py
+```
+
+Skip them or mark them `CENSORED` with note
+`device-side printf unsupported`.
+
+## Guest Environment Prefix
+
+For special environment rows:
+
+```bash
+GUEST_TEST_PREFIX="HSA_ENABLE_INTERRUPT=0" bash scripts/run_cosim_tests.sh vector_add
+```
+
+Guest workload defaults and prefix parsing are centralized in
+`scripts/cosim_guest_env.sh`. Do not add ad hoc ROCm exports inside generated
+guest commands; extend the shared helper instead.
+
+The runner records effective `HSA_ENABLE_INTERRUPT` from guest output, not from
+the host shell. If the guest log shows an environment assignment being treated
+as an executable, treat that as a runner bug, fix the invocation path, and rerun
+the intended program.
+
+For environment policy questions, inspect `scripts/cosim_guest_env.sh`, then
+`scripts/run_cosim_tests.sh`. Use debug only after a test row fails or a live
+hang environment exists.

--- a/.agents/skills/cosim-gpu-test/references/run-manifest-and-provenance.md
+++ b/.agents/skills/cosim-gpu-test/references/run-manifest-and-provenance.md
@@ -1,0 +1,98 @@
+# Run Manifest And Provenance
+
+Read this when a cosim test task uses automation, repeats, environment rows,
+non-default binaries, or evidence that must prove an uncommitted source state.
+
+## Manifest Gate
+
+Before automation, write or append
+`artifacts/<task-slug>/tests/run-manifest.tsv`. Each row must name:
+
+- exact program identity
+- mode: `pure_test` or `hang_env`
+- repeat count
+- timeout policy
+- literal `GUEST_TEST_PREFIX`, if any
+- expected `HSA_ENABLE_INTERRUPT`
+- gem5 binary path
+- gem5 config arguments, if any
+- output directory
+- exact `artifact_dir`, or an `artifact_dir_pattern` that will resolve to one
+  row after launch
+- matrix path
+- provenance file
+- literal runner argument
+- guest bridge path policy, when the runner uses a host-created script or
+  temporary output directory that must be visible inside the guest
+
+Automation may execute only complete rows. Do not infer the target from nearby
+filenames, prior conversation, partial filters, or failed discovery commands.
+`--all` is valid only when the user explicitly requests all tests or the active
+plan names it as the scope.
+
+If a row has ambiguous program identity, conflicting timeout policy, unknown
+guest environment, missing artifact path, missing matrix path, missing
+binary/provenance data, or a mode mismatch, record a preflight failure and do
+not launch it.
+
+Artifact paths and guest bridge paths are different concerns. The artifact
+directory is the durable evidence destination and may follow local host storage
+policy. The guest bridge path is a transient path used by scripts executing
+under `/mnt`; it must resolve inside the mounted share without relying on host
+absolute paths or symlinks that leave the share. Prefer a configurable
+repository-relative bridge path, archive the bridge script and guest output into
+the artifact directory, and remove transient bridge contents during cleanup.
+
+## Artifact Resolution
+
+Use `artifact_dir` when known before launch. Otherwise resolve the exact
+directory immediately after launch from:
+
+1. runner output
+2. `metadata.txt` run id
+3. a unique directory matching `artifact_dir_pattern`
+
+Zero or multiple matches is a checkpoint failure. Do not accept the row until a
+single exact artifact directory is recorded.
+
+## Acceptance Checks
+
+Final acceptance must come from artifacts, not from the manifest alone. Verify:
+
+- `metadata.txt` and `matrix.tsv` under `artifact_dir`
+- `verdict.json` or `[COSIM_VERDICT]` from the same `artifact_dir`
+- effective guest environment from `[COSIM_ENV] HSA_ENABLE_INTERRUPT=<value>`
+- provenance file contains `gem5_source_commit`, `gem5_binary`, and
+  `gem5_sha256`
+- effective gem5 config arguments match the manifest when
+  `--gem5-config-arg` is used
+- `patch/source-snapshot.txt` exists, has no `error=not_a_git_repository`, and
+  records `head_commit` plus `source_fingerprint`
+- `patch/gem5-status.txt` exists
+- `patch/gem5.patch` represents `git diff --binary --no-ext-diff HEAD`; if it
+  is empty, tracked modifications must also be absent
+- untracked source files listed in `patch/untracked-files.txt` have
+  `patch/untracked-files.tar`
+- the top-level matrix contains the row copied or summarized from the same
+  artifact directory
+
+If source snapshot fails, classify the row as evidence-incomplete. Binary
+provenance can identify the executable, but cannot replay uncommitted source
+changes by itself.
+
+## Build Gate
+
+For review, RLCR, debug validation, and PR evidence, use the build and
+provenance gate from `cosim-gpu-build`. Pass the standard gem5 binary
+explicitly when needed:
+
+```bash
+bash scripts/run_cosim_tests.sh \
+  --gem5-bin gem5/build/VEGA_X86/gem5.opt \
+  --test-timeout 120 \
+  --output-dir artifacts/<slug>/<case> \
+  <program>
+```
+
+The runner writes provenance artifacts before launch. If that gate fails,
+follow `cosim-gpu-build`; do not duplicate its metadata rules here.

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,6 +6,3 @@
 	path = gem5-resources
 	url = git@github.com:gevico/gem5-resources.git
 	branch = cosim-gpu
-[submodule ".agents"]
-	path = .agents
-	url = git@github.com:gevico/cosim-gpu-skills.git

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ cosim-gpu/
 |   |-- ext/libvfio-user/    # libvfio-user library (Nutanix)
 |   `-- configs/example/gpufs/mi300_cosim.py  # cosim configuration
 |-- gem5-resources/          # disk images, kernels, GPU apps (submodule)
-|-- .agents/                 # reusable repository workflows (submodule)
+|-- .agents/                 # reusable repository workflows (vendored)
 |-- scripts/                 # build & launch scripts
 |   |-- cosim_launch.sh      # one-click cosim launcher
 |   |-- run_mi300x_fs.sh     # build orchestration

--- a/README.zh.md
+++ b/README.zh.md
@@ -144,7 +144,7 @@ cosim-gpu/
 |   |-- ext/libvfio-user/    # libvfio-user library (Nutanix)
 |   `-- configs/example/gpufs/mi300_cosim.py  # cosim configuration
 |-- gem5-resources/          # disk images, kernels, GPU apps (submodule)
-|-- .agents/                 # 可复用的仓库工作流（子模块）
+|-- .agents/                 # 可复用的仓库工作流（已内置）
 |-- scripts/                 # build & launch scripts
 |   |-- cosim_launch.sh      # one-click cosim launcher
 |   |-- run_mi300x_fs.sh     # build orchestration

--- a/agents.md
+++ b/agents.md
@@ -3,8 +3,9 @@
 ## Scope
 
 This repository hosts the QEMU + gem5 MI300X GPU co-simulation source tree.
-Reusable agent workflows are no longer stored as `.claude/commands`; they live in
-the `.agents` submodule, which points at `gevico/cosim-gpu-skills`.
+Reusable agent workflows are no longer stored as `.claude/commands`; they are
+vendored in-tree under `.agents/skills/` (previously the
+`gevico/cosim-gpu-skills` submodule) and are tracked directly by this repository.
 
 `CLAUDE.md` is a symbolic mapping to this file so Claude-compatible tools read
 the same canonical rules.
@@ -15,10 +16,10 @@ Load the matching skill before running these workflows:
 
 - Debugging co-simulation failures: `.agents/skills/cosim-gpu-debug/SKILL.md`
 - Guest serial interaction and GPU test runs: `.agents/skills/cosim-gpu-guest/SKILL.md`
-- Guest disk-image edits with `guestmount`: `.agents/skills/cosim-gpu-disk-image/SKILL.md`
+- Guest disk-image edits with `guestmount`: `.agents/skills/cosim-gpu-disk-image-edit/SKILL.md`
 
 Do not add new project-specific command implementations under `.claude/commands`.
-Add reusable workflows to `cosim-gpu-skills` instead, then update this mapping.
+Add reusable workflows under `.agents/skills/` instead, then update this mapping.
 
 ## Build
 


### PR DESCRIPTION
## Summary

- Remove the `.agents` skill submodule from `.gitmodules` and convert `.agents` into a normal tracked directory.
- Copy all 47 files from `gevico/cosim-gpu-skills` at commit `656347c` directly into this repository.
- Update `agents.md` to describe the vendored skills, and fix the disk-image skill path to `cosim-gpu-disk-image-edit`.
- Update `README.md` / `README.zh.md` repository structure notes.
- Update the vendored `cosim-gpu-repo-maintenance` skill and policy to reflect that `.agents` changes are now ordinary top-level changes.

Remaining submodules: `gem5` and `gem5-resources`.